### PR TITLE
Updates on v1.1

### DIFF
--- a/githubify.py
+++ b/githubify.py
@@ -23,4 +23,4 @@ if __name__ == "__main__":
                     f.write(FILE_REDIRECT_TEMPLATE.substitute(redirect_to=os.path.join(root_name, root, fname+'.jsonld')))
                 os.makedirs(os.path.join(root, fname), exist_ok=True)
                 with open(os.path.join(root, fname, 'index.md'), 'w') as f:
-                    f.write(FILE_REDIRECT_TEMPLATE.substitute(redirect_to=os.path.join(root_name, root, '..', fname+'.jsonld')))
+                    f.write(FILE_REDIRECT_TEMPLATE.substitute(redirect_to=os.path.join(root_name, root, fname+'.jsonld')))

--- a/v1/ClassDefinitions/Building.jsonld
+++ b/v1/ClassDefinitions/Building.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Building name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name of the building"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -217,8 +235,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -252,8 +270,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "10",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "10"
                 }
             },
             "idOfficialTemporary": {
@@ -288,8 +306,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "inaugurationMomentYear": {
@@ -324,24 +342,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:gYear"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Building name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name of the building"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement.jsonld
+++ b/v1/ClassDefinitions/BuildingElement.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/Beam.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/Beam.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/Column.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/Column.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/CurtainWall.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/CurtainWall.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/Door.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/Door.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/Floor.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/Floor.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/Roof.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/Roof.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/Slab.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/Slab.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/Stair.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/Stair.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/Wall.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/Wall.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingElement/Window.jsonld
+++ b/v1/ClassDefinitions/BuildingElement/Window.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the building element"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -325,8 +343,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -343,8 +361,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "length": {
@@ -362,24 +380,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the building element"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/BuildingSystems.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/BuildingSystems/AirConditioningSystem.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems/AirConditioningSystem.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/BuildingSystems/BuildingAutomationSystem.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems/BuildingAutomationSystem.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/BuildingSystems/HeatingSystem.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems/HeatingSystem.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/BuildingSystems/LightingSystem.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems/LightingSystem.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/BuildingSystems/PowerSystem.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems/PowerSystem.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/BuildingSystems/SecuritySystem.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems/SecuritySystem.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/BuildingSystems/SewageSystem.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems/SewageSystem.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/BuildingSystems/VentilationSystem.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems/VentilationSystem.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/BuildingSystems/VideoSurveillanceSystem.jsonld
+++ b/v1/ClassDefinitions/BuildingSystems/VideoSurveillanceSystem.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",

--- a/v1/ClassDefinitions/Case.jsonld
+++ b/v1/ClassDefinitions/Case.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -148,8 +164,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "duration": {
@@ -205,8 +221,8 @@
                     "xsd:base": "xsd:dateTime"
                 }
             },
-            "idlocal": {
-                "@id": "pot:identifier/idlocal",
+            "idLocal": {
+                "@id": "pot:identifier/idLocal",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
                 "dli:title": "Case Id",
@@ -219,8 +235,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "nameLocal": {

--- a/v1/ClassDefinitions/Device.jsonld
+++ b/v1/ClassDefinitions/Device.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/AirFilteringDevice.jsonld
+++ b/v1/ClassDefinitions/Device/AirFilteringDevice.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/HeatingDevice.jsonld
+++ b/v1/ClassDefinitions/Device/HeatingDevice.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/HeatingDevice/Radiator.jsonld
+++ b/v1/ClassDefinitions/Device/HeatingDevice/Radiator.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/PowerDevice.jsonld
+++ b/v1/ClassDefinitions/Device/PowerDevice.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/QrCode.jsonld
+++ b/v1/ClassDefinitions/Device/QrCode.jsonld
@@ -27,15 +27,15 @@
                 "@set"
             ]
         },
-        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Device/AirConditioningDevice"
+        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Device/QrCode"
     },
-    "@id": "https://standards.oftrust.net/v1/Vocabulary/Device/AirConditioningDevice",
+    "@id": "https://standards.oftrust.net/v1/Vocabulary/Device/QrCode",
     "dli:supportedClass": {
-        "@id": "pot:Device/AirConditioningDevice",
+        "@id": "pot:Device/QrCode",
         "@type": "pot:Class",
         "subClassOf": "pot:Device",
         "rdfs:label": {
-            "en-us": "Air Conditioning Device"
+            "en-us": "QR Code"
         },
         "dli:supportedAttribute": {
             "data": {

--- a/v1/ClassDefinitions/Device/SecurityDevice.jsonld
+++ b/v1/ClassDefinitions/Device/SecurityDevice.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/Sensor.jsonld
+++ b/v1/ClassDefinitions/Device/Sensor.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/Sensor/CarbonDioxideSensor.jsonld
+++ b/v1/ClassDefinitions/Device/Sensor/CarbonDioxideSensor.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/Sensor/HumiditySensor.jsonld
+++ b/v1/ClassDefinitions/Device/Sensor/HumiditySensor.jsonld
@@ -27,15 +27,15 @@
                 "@set"
             ]
         },
-        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Device/AirConditioningDevice"
+        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Device/Sensor/HumiditySensor"
     },
-    "@id": "https://standards.oftrust.net/v1/Vocabulary/Device/AirConditioningDevice",
+    "@id": "https://standards.oftrust.net/v1/Vocabulary/Device/Sensor/HumiditySensor",
     "dli:supportedClass": {
-        "@id": "pot:Device/AirConditioningDevice",
+        "@id": "pot:Device/Sensor/HumiditySensor",
         "@type": "pot:Class",
-        "subClassOf": "pot:Device",
+        "subClassOf": "pot:Device/Sensor",
         "rdfs:label": {
-            "en-us": "Air Conditioning Device"
+            "en-us": "Humidity Sensor"
         },
         "dli:supportedAttribute": {
             "data": {

--- a/v1/ClassDefinitions/Device/Sensor/PresenceSensor.jsonld
+++ b/v1/ClassDefinitions/Device/Sensor/PresenceSensor.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/Sensor/QuantitySensor.jsonld
+++ b/v1/ClassDefinitions/Device/Sensor/QuantitySensor.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/Sensor/TemperatureSensor.jsonld
+++ b/v1/ClassDefinitions/Device/Sensor/TemperatureSensor.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/VentilationDevice.jsonld
+++ b/v1/ClassDefinitions/Device/VentilationDevice.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/WaterDevice.jsonld
+++ b/v1/ClassDefinitions/Device/WaterDevice.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Device/WaterDevice/Faucet.jsonld
+++ b/v1/ClassDefinitions/Device/WaterDevice/Faucet.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given locally for the device"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -200,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "colorCode": {
@@ -218,8 +236,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "colorName": {
@@ -254,8 +272,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "electricityCurrent": {
@@ -324,8 +342,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -342,8 +360,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "industryDomain": {
@@ -360,8 +378,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "length": {
@@ -379,24 +397,6 @@
                 ],
                 "xsd:restriction": {
                     "xsd:base": "xsd:decimal"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name given locally for the device"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
                 }
             },
             "power": {
@@ -430,8 +430,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "100"
+                    "xsd:maxLength": "100",
+                    "xsd:base": "xsd:string"
                 }
             },
             "status": {

--- a/v1/ClassDefinitions/Organization.jsonld
+++ b/v1/ClassDefinitions/Organization.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Organization name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name of the organization"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -166,8 +184,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "governmentPermanent": {
@@ -202,26 +220,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Organization name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name of the organization"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
                     "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:length": "22"
                 }
             },
             "status": {
@@ -256,8 +256,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "12",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "12"
                 }
             }
         }

--- a/v1/ClassDefinitions/Organization/LimitedCompany.jsonld
+++ b/v1/ClassDefinitions/Organization/LimitedCompany.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Organization name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name of the organization"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -166,8 +184,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "governmentPermanent": {
@@ -202,26 +220,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Organization name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name of the organization"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
                     "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:length": "22"
                 }
             },
             "status": {
@@ -256,8 +256,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "12",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "12"
                 }
             }
         }

--- a/v1/ClassDefinitions/Organization/LimitedCompany/HousingCooperative.jsonld
+++ b/v1/ClassDefinitions/Organization/LimitedCompany/HousingCooperative.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Organization name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name of the organization"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -166,8 +184,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "governmentPermanent": {
@@ -202,26 +220,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Organization name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name of the organization"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
                     "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:length": "22"
                 }
             },
             "status": {
@@ -256,8 +256,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "12",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "12"
                 }
             }
         }

--- a/v1/ClassDefinitions/Room.jsonld
+++ b/v1/ClassDefinitions/Room.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Room name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Room name"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -148,8 +166,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "carbonDioxide": {
@@ -219,8 +237,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -240,15 +258,15 @@
                     "xsd:base": "xsd:decimal"
                 }
             },
-            "idOfficial": {
-                "@id": "pot:identifier/idOfficial",
+            "idLocal": {
+                "@id": "pot:identifier/idLocal",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
-                "dli:title": "Official Id",
+                "dli:title": "Local Id",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Officially given identifier for the space"
+                    "en-us": "Locally given identifier for the space"
                 },
                 "dli:valueType": [
                     "xsd:string"
@@ -258,15 +276,15 @@
                     "xsd:maxLength": "50"
                 }
             },
-            "idlocal": {
-                "@id": "pot:identifier/idlocal",
+            "idOfficial": {
+                "@id": "pot:identifier/idOfficial",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
-                "dli:title": "Local Id",
+                "dli:title": "Official Id",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Locally given identifier for the space"
+                    "en-us": "Officially given identifier for the space"
                 },
                 "dli:valueType": [
                     "xsd:string"
@@ -290,26 +308,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Room name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Room name"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
                     "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:length": "22"
                 }
             },
             "presence": {

--- a/v1/ClassDefinitions/Space.jsonld
+++ b/v1/ClassDefinitions/Space.jsonld
@@ -103,6 +103,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -149,8 +165,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "categorizationLocal": {
@@ -203,8 +219,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -224,15 +240,15 @@
                     "xsd:base": "xsd:decimal"
                 }
             },
-            "idOfficial": {
-                "@id": "pot:identifier/idOfficial",
+            "idLocal": {
+                "@id": "pot:identifier/idLocal",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
-                "dli:title": "Official Id",
+                "dli:title": "Local Id",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Officially given identifier for the space in Finland"
+                    "en-us": "Locally given identifier for the space"
                 },
                 "dli:valueType": [
                     "xsd:string"
@@ -242,15 +258,15 @@
                     "xsd:maxLength": "50"
                 }
             },
-            "idlocal": {
-                "@id": "pot:identifier/idlocal",
+            "idOfficial": {
+                "@id": "pot:identifier/idOfficial",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
-                "dli:title": "Local Id",
+                "dli:title": "Official Id",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Locally given identifier for the space"
+                    "en-us": "Officially given identifier for the space in Finland"
                 },
                 "dli:valueType": [
                     "xsd:string"
@@ -274,8 +290,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "sizeAreaFloor": {

--- a/v1/ClassDefinitions/Space/Apartment.jsonld
+++ b/v1/ClassDefinitions/Space/Apartment.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Apartment name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Apartment name"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -148,8 +166,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "categorizationLocal": {
@@ -202,8 +220,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "descriptionKitchen": {
@@ -241,15 +259,15 @@
                     "xsd:base": "xsd:decimal"
                 }
             },
-            "idOfficial": {
-                "@id": "pot:identifier/idOfficial",
+            "idLocal": {
+                "@id": "pot:identifier/idLocal",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
-                "dli:title": "Official Id",
+                "dli:title": "Local Id",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Officially given identifier for the space in Finland"
+                    "en-us": "Locally given identifier for the space"
                 },
                 "dli:valueType": [
                     "xsd:string"
@@ -259,15 +277,15 @@
                     "xsd:maxLength": "50"
                 }
             },
-            "idlocal": {
-                "@id": "pot:identifier/idlocal",
+            "idOfficial": {
+                "@id": "pot:identifier/idOfficial",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
-                "dli:title": "Local Id",
+                "dli:title": "Official Id",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Locally given identifier for the space"
+                    "en-us": "Officially given identifier for the space in Finland"
                 },
                 "dli:valueType": [
                     "xsd:string"
@@ -291,26 +309,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Apartment name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Apartment name"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
                     "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:length": "22"
                 }
             },
             "roomAmount": {

--- a/v1/ClassDefinitions/Space/RealEstate.jsonld
+++ b/v1/ClassDefinitions/Space/RealEstate.jsonld
@@ -102,6 +102,24 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "pot:identifier/name",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name of the real estate"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -148,8 +166,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "areaSquareMeter": {
@@ -183,8 +201,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "areaTypeRegistration": {
@@ -255,8 +273,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "descriptionGeneral": {
@@ -273,8 +291,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -294,6 +312,24 @@
                     "xsd:base": "xsd:decimal"
                 }
             },
+            "idLocal": {
+                "@id": "pot:identifier/idLocal",
+                "@type": "dli:SupportedAttribute",
+                "subPropertyOf": "pot:identifier",
+                "dli:title": "Local Id",
+                "dli:required": false,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Locally given identifier for the space"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
+                }
+            },
             "idOfficial": {
                 "@id": "pot:identifier/idOfficial",
                 "@type": "dli:SupportedAttribute",
@@ -302,14 +338,14 @@
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Officially given identifier for the space in Finland"
+                    "en-us": "Real estate identifier for the land in Finland"
                 },
                 "dli:valueType": [
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
+                    "xsd:maxLength": "50",
+                    "xsd:base": "xsd:string"
                 }
             },
             "idOfficialUnseparatedLand": {
@@ -326,26 +362,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
-                }
-            },
-            "idlocal": {
-                "@id": "pot:identifier/idlocal",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Local Id",
-                "dli:required": false,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Locally given identifier for the space"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -362,8 +380,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "locationUnseparatedLand": {
@@ -375,24 +393,6 @@
                 "dli:readonly": false,
                 "dli:description": {
                     "en-us": "Real estate is located on an unseparated piece of land"
-                },
-                "dli:valueType": [
-                    "xsd:string"
-                ],
-                "xsd:restriction": {
-                    "xsd:base": "xsd:string",
-                    "xsd:maxLength": "50"
-                }
-            },
-            "name": {
-                "@id": "pot:identifier/name",
-                "@type": "dli:SupportedAttribute",
-                "subPropertyOf": "pot:identifier",
-                "dli:title": "Name",
-                "dli:required": true,
-                "dli:readonly": false,
-                "dli:description": {
-                    "en-us": "Name of the real estate"
                 },
                 "dli:valueType": [
                     "xsd:string"

--- a/v1/ClassDefinitions/Space/Zone.jsonld
+++ b/v1/ClassDefinitions/Space/Zone.jsonld
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -148,8 +164,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "categorizationLocal": {
@@ -202,8 +218,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "height": {
@@ -223,15 +239,15 @@
                     "xsd:base": "xsd:decimal"
                 }
             },
-            "idOfficial": {
-                "@id": "pot:identifier/idOfficial",
+            "idLocal": {
+                "@id": "pot:identifier/idLocal",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
-                "dli:title": "Official Id",
+                "dli:title": "Local Id",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Officially given identifier for the space in Finland"
+                    "en-us": "Locally given identifier for the space"
                 },
                 "dli:valueType": [
                     "xsd:string"
@@ -241,15 +257,15 @@
                     "xsd:maxLength": "50"
                 }
             },
-            "idlocal": {
-                "@id": "pot:identifier/idlocal",
+            "idOfficial": {
+                "@id": "pot:identifier/idOfficial",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
-                "dli:title": "Local Id",
+                "dli:title": "Official Id",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Locally given identifier for the space"
+                    "en-us": "Officially given identifier for the space in Finland"
                 },
                 "dli:valueType": [
                     "xsd:string"
@@ -273,8 +289,8 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "sizeAreaFloor": {

--- a/v1/ClassDefinitions/Storey.jsonld
+++ b/v1/ClassDefinitions/Storey.jsonld
@@ -27,15 +27,15 @@
                 "@set"
             ]
         },
-        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Story"
+        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Storey"
     },
-    "@id": "https://standards.oftrust.net/v1/Vocabulary/Story",
+    "@id": "https://standards.oftrust.net/v1/Vocabulary/Storey",
     "dli:supportedClass": {
-        "@id": "pot:Story",
+        "@id": "pot:Storey",
         "@type": "pot:Class",
         "subClassOf": "dli:BuiltEnvironment",
         "rdfs:label": {
-            "en-us": "Story"
+            "en-us": "Storey"
         },
         "dli:supportedAttribute": {
             "data": {
@@ -102,6 +102,22 @@
                     "xsd:base": "xsd:object"
                 }
             },
+            "name": {
+                "@id": "dli:name",
+                "@type": "dli:SupportedAttribute",
+                "dli:title": "Identity name",
+                "dli:required": true,
+                "dli:readonly": false,
+                "dli:description": {
+                    "en-us": "Name given to the Identity"
+                },
+                "dli:valueType": [
+                    "xsd:string"
+                ],
+                "xsd:restriction": {
+                    "xsd:base": "xsd:string"
+                }
+            },
             "updatedAt": {
                 "@id": "dli:updatedAt",
                 "@type": "dli:SupportedAttribute",
@@ -148,44 +164,44 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
             "descriptionGeneral": {
                 "@id": "pot:description/descriptionGeneral",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:description",
-                "dli:title": "Story description",
+                "dli:title": "Storey description",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Description of the story"
+                    "en-us": "Description of the storey"
                 },
                 "dli:valueType": [
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "500",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "500"
                 }
             },
-            "idlocal": {
-                "@id": "pot:identifier/idlocal",
+            "idLocal": {
+                "@id": "pot:identifier/idLocal",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:identifier",
                 "dli:title": "Local Id",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Locally given identifier for the story"
+                    "en-us": "Locally given identifier for the storey"
                 },
                 "dli:valueType": [
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:maxLength": "50",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:maxLength": "50"
                 }
             },
             "ifcGuid": {
@@ -202,19 +218,19 @@
                     "xsd:string"
                 ],
                 "xsd:restriction": {
-                    "xsd:length": "22",
-                    "xsd:base": "xsd:string"
+                    "xsd:base": "xsd:string",
+                    "xsd:length": "22"
                 }
             },
             "sizeArea": {
                 "@id": "pot:physical/sizeArea",
                 "@type": "dli:SupportedAttribute",
                 "subPropertyOf": "pot:physical",
-                "dli:title": "Story area size",
+                "dli:title": "Storey area size",
                 "dli:required": false,
                 "dli:readonly": false,
                 "dli:description": {
-                    "en-us": "Area of the story"
+                    "en-us": "Area of the storey"
                 },
                 "dli:valueType": [
                     "xsd:decimal"

--- a/v1/Context/Identity/Building.jsonld
+++ b/v1/Context/Identity/Building.jsonld
@@ -17,6 +17,22 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaSquareMeterFloorNet": {
+            "@id": "pot:physical/areaSquareMeterFloorNet",
+            "@nest": "data"
+        },
+        "idOfficialTemporary": {
+            "@id": "pot:identifier/idOfficialTemporary",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
+        },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
@@ -25,36 +41,8 @@
             "@id": "pot:lifeCycle/inaugurationMomentYear",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "cultureHistorySignificance": {
-            "@id": "pot:categorization/cultureHistorySignificance",
-            "@nest": "data"
-        },
-        "areaSquareMeterFloorNet": {
-            "@id": "pot:physical/areaSquareMeterFloorNet",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "idOfficialPermanent": {
-            "@id": "pot:identifier/idOfficialPermanent",
-            "@nest": "data"
-        },
-        "inspectionMomentYear": {
-            "@id": "pot:lifeCycle/inspectionMomentYear",
-            "@nest": "data"
-        },
-        "areaSquareMeterLivingNet": {
-            "@id": "pot:physical/areaSquareMeterLivingNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -65,28 +53,40 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
+        },
+        "inspectionMomentYear": {
+            "@id": "pot:lifeCycle/inspectionMomentYear",
+            "@nest": "data"
+        },
+        "idOfficialPermanent": {
+            "@id": "pot:identifier/idOfficialPermanent",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "completionMomentYear": {
-            "@id": "pot:lifeCycle/completionMomentYear",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "idOfficialTemporary": {
-            "@id": "pot:identifier/idOfficialTemporary",
+        "completionMomentYear": {
+            "@id": "pot:lifeCycle/completionMomentYear",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "cultureHistorySignificance": {
+            "@id": "pot:categorization/cultureHistorySignificance",
+            "@nest": "data"
+        },
+        "areaSquareMeterLivingNet": {
+            "@id": "pot:physical/areaSquareMeterLivingNet",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/BuildingElement.jsonld
+++ b/v1/Context/Identity/BuildingElement.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingElement/Beam.jsonld
+++ b/v1/Context/Identity/BuildingElement/Beam.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingElement/Column.jsonld
+++ b/v1/Context/Identity/BuildingElement/Column.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingElement/CurtainWall.jsonld
+++ b/v1/Context/Identity/BuildingElement/CurtainWall.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingElement/Door.jsonld
+++ b/v1/Context/Identity/BuildingElement/Door.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingElement/Floor.jsonld
+++ b/v1/Context/Identity/BuildingElement/Floor.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingElement/Roof.jsonld
+++ b/v1/Context/Identity/BuildingElement/Roof.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingElement/Slab.jsonld
+++ b/v1/Context/Identity/BuildingElement/Slab.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingElement/Stair.jsonld
+++ b/v1/Context/Identity/BuildingElement/Stair.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingElement/Wall.jsonld
+++ b/v1/Context/Identity/BuildingElement/Wall.jsonld
@@ -17,9 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "width": {
+            "@id": "pot:physical/width",
+            "@nest": "data"
+        },
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
+        },
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
+            "@nest": "data"
+        },
+        "idInstance": {
+            "@id": "pot:identifier/idInstance",
+            "@nest": "data"
+        },
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "length": {
+            "@id": "pot:physical/length",
+            "@nest": "data"
+        },
         "codeLocal": {
             "@id": "pot:identifier/codeLocal",
             "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
@@ -29,36 +61,12 @@
             "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "colorName": {
-            "@id": "pot:physical/colorName",
-            "@nest": "data"
-        },
-        "length": {
-            "@id": "pot:physical/length",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
-            "@nest": "data"
-        },
-        "width": {
-            "@id": "pot:physical/width",
-            "@nest": "data"
-        },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -69,45 +77,37 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
-            "@nest": "data"
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/BuildingSystems.jsonld
+++ b/v1/Context/Identity/BuildingSystems.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/BuildingSystems/AirConditioningSystem.jsonld
+++ b/v1/Context/Identity/BuildingSystems/AirConditioningSystem.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/BuildingSystems/BuildingAutomationSystem.jsonld
+++ b/v1/Context/Identity/BuildingSystems/BuildingAutomationSystem.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/BuildingSystems/HeatingSystem.jsonld
+++ b/v1/Context/Identity/BuildingSystems/HeatingSystem.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/BuildingSystems/LightingSystem.jsonld
+++ b/v1/Context/Identity/BuildingSystems/LightingSystem.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/BuildingSystems/PowerSystem.jsonld
+++ b/v1/Context/Identity/BuildingSystems/PowerSystem.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/BuildingSystems/SecuritySystem.jsonld
+++ b/v1/Context/Identity/BuildingSystems/SecuritySystem.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/BuildingSystems/SewageSystem.jsonld
+++ b/v1/Context/Identity/BuildingSystems/SewageSystem.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/BuildingSystems/VentilationSystem.jsonld
+++ b/v1/Context/Identity/BuildingSystems/VentilationSystem.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/BuildingSystems/VideoSurveillanceSystem.jsonld
+++ b/v1/Context/Identity/BuildingSystems/VideoSurveillanceSystem.jsonld
@@ -17,20 +17,23 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "name": {
+            "@id": "dli:name"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Identity/Case.jsonld
+++ b/v1/Context/Identity/Case.jsonld
@@ -17,52 +17,55 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
         "descriptionGeneral": {
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
-        },
-        "endDateTime": {
-            "@id": "pot:time/endDateTime",
-            "@nest": "data"
-        },
-        "idlocal": {
-            "@id": "pot:identifier/idlocal",
-            "@nest": "data"
-        },
-        "startDateTime": {
-            "@id": "pot:time/startDateTime",
-            "@nest": "data"
-        },
-        "status": {
-            "@id": "pot:lifeCycle/status",
-            "@nest": "data"
-        },
-        "durationEstimate": {
-            "@id": "pot:time/durationEstimate",
-            "@nest": "data"
-        },
-        "duration": {
-            "@id": "pot:time/duration",
+        "nameLocal": {
+            "@id": "pot:identifier/nameLocal",
             "@nest": "data"
         },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "nameLocal": {
-            "@id": "pot:identifier/nameLocal",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "startDateTime": {
+            "@id": "pot:time/startDateTime",
+            "@nest": "data"
+        },
+        "idLocal": {
+            "@id": "pot:identifier/idLocal",
+            "@nest": "data"
+        },
+        "name": {
+            "@id": "dli:name"
+        },
+        "endDateTime": {
+            "@id": "pot:time/endDateTime",
+            "@nest": "data"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "durationEstimate": {
+            "@id": "pot:time/durationEstimate",
+            "@nest": "data"
+        },
+        "status": {
+            "@id": "pot:lifeCycle/status",
+            "@nest": "data"
+        },
+        "duration": {
+            "@id": "pot:time/duration",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device.jsonld
+++ b/v1/Context/Identity/Device.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/AirConditioningDevice.jsonld
+++ b/v1/Context/Identity/Device/AirConditioningDevice.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/AirFilteringDevice.jsonld
+++ b/v1/Context/Identity/Device/AirFilteringDevice.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/HeatingDevice.jsonld
+++ b/v1/Context/Identity/Device/HeatingDevice.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/HeatingDevice/Radiator.jsonld
+++ b/v1/Context/Identity/Device/HeatingDevice/Radiator.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/PowerDevice.jsonld
+++ b/v1/Context/Identity/Device/PowerDevice.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/QrCode.jsonld
+++ b/v1/Context/Identity/Device/QrCode.jsonld
@@ -1,8 +1,8 @@
 {
     "@context": {
         "@version": 1.1,
-        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/BuildingElement/Window",
-        "@classDefinition": "https://standards.oftrust.net/v1/ClassDefinitions/BuildingElement/Window",
+        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Device/QrCode",
+        "@classDefinition": "https://standards.oftrust.net/v1/ClassDefinitions/Device/QrCode",
         "pot": {
             "@id": "https://standards.oftrust.net/v1/Vocabulary/",
             "@prefix": true
@@ -17,6 +17,10 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
+            "@nest": "data"
+        },
         "width": {
             "@id": "pot:physical/width",
             "@nest": "data"
@@ -29,12 +33,12 @@
             "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
-            "@nest": "data"
-        },
         "areaGross": {
             "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "industryDomain": {
+            "@id": "pot:categorization/industryDomain",
             "@nest": "data"
         },
         "length": {
@@ -85,6 +89,10 @@
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
+        "power": {
+            "@id": "pot:physical/power",
+            "@nest": "data"
+        },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
@@ -108,6 +116,10 @@
         "createdAt": {
             "@id": "dli:createdAt",
             "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
+            "@nest": "data"
         }
     }
 }

--- a/v1/Context/Identity/Device/SecurityDevice.jsonld
+++ b/v1/Context/Identity/Device/SecurityDevice.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/Sensor.jsonld
+++ b/v1/Context/Identity/Device/Sensor.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/Sensor/CarbonDioxideSensor.jsonld
+++ b/v1/Context/Identity/Device/Sensor/CarbonDioxideSensor.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/Sensor/HumiditySensor.jsonld
+++ b/v1/Context/Identity/Device/Sensor/HumiditySensor.jsonld
@@ -1,8 +1,8 @@
 {
     "@context": {
         "@version": 1.1,
-        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/BuildingElement/Window",
-        "@classDefinition": "https://standards.oftrust.net/v1/ClassDefinitions/BuildingElement/Window",
+        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Device/Sensor/HumiditySensor",
+        "@classDefinition": "https://standards.oftrust.net/v1/ClassDefinitions/Device/Sensor/HumiditySensor",
         "pot": {
             "@id": "https://standards.oftrust.net/v1/Vocabulary/",
             "@prefix": true
@@ -17,6 +17,10 @@
         "metadata": {
             "@id": "dli:metadata"
         },
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
+            "@nest": "data"
+        },
         "width": {
             "@id": "pot:physical/width",
             "@nest": "data"
@@ -29,12 +33,12 @@
             "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "idInstance": {
-            "@id": "pot:identifier/idInstance",
-            "@nest": "data"
-        },
         "areaGross": {
             "@id": "pot:physical/areaGross",
+            "@nest": "data"
+        },
+        "industryDomain": {
+            "@id": "pot:categorization/industryDomain",
             "@nest": "data"
         },
         "length": {
@@ -85,6 +89,10 @@
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
+        "power": {
+            "@id": "pot:physical/power",
+            "@nest": "data"
+        },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
@@ -108,6 +116,10 @@
         "createdAt": {
             "@id": "dli:createdAt",
             "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
+            "@nest": "data"
         }
     }
 }

--- a/v1/Context/Identity/Device/Sensor/PresenceSensor.jsonld
+++ b/v1/Context/Identity/Device/Sensor/PresenceSensor.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/Sensor/QuantitySensor.jsonld
+++ b/v1/Context/Identity/Device/Sensor/QuantitySensor.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/Sensor/TemperatureSensor.jsonld
+++ b/v1/Context/Identity/Device/Sensor/TemperatureSensor.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/VentilationDevice.jsonld
+++ b/v1/Context/Identity/Device/VentilationDevice.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/WaterDevice.jsonld
+++ b/v1/Context/Identity/Device/WaterDevice.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Device/WaterDevice/Faucet.jsonld
+++ b/v1/Context/Identity/Device/WaterDevice/Faucet.jsonld
@@ -17,40 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "codeLocal": {
-            "@id": "pot:identifier/codeLocal",
+        "electricityCurrent": {
+            "@id": "pot:physical/electricityCurrent",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "serialNumber": {
-            "@id": "pot:identifier/serialNumber",
+        "width": {
+            "@id": "pot:physical/width",
             "@nest": "data"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
-        "colorName": {
-            "@id": "pot:physical/colorName",
+        "areaNet": {
+            "@id": "pot:physical/areaNet",
             "@nest": "data"
         },
-        "electricityCurrent": {
-            "@id": "pot:physical/electricityCurrent",
-            "@nest": "data"
-        },
-        "power": {
-            "@id": "pot:physical/power",
+        "areaGross": {
+            "@id": "pot:physical/areaGross",
             "@nest": "data"
         },
         "industryDomain": {
@@ -61,20 +45,32 @@
             "@id": "pot:physical/length",
             "@nest": "data"
         },
+        "codeLocal": {
+            "@id": "pot:identifier/codeLocal",
+            "@nest": "data"
+        },
+        "colorName": {
+            "@id": "pot:physical/colorName",
+            "@nest": "data"
+        },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "colorCode": {
-            "@id": "pot:physical/colorCode",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
-        "width": {
-            "@id": "pot:physical/width",
+        "ifcElementName": {
+            "@id": "pot:categorization/ifcElementName",
             "@nest": "data"
         },
-        "areaNet": {
-            "@id": "pot:physical/areaNet",
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -85,40 +81,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
             "@nest": "data"
         },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "ifcElementName": {
-            "@id": "pot:categorization/ifcElementName",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
+        "power": {
+            "@id": "pot:physical/power",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaGross": {
-            "@id": "pot:physical/areaGross",
+        "colorCode": {
+            "@id": "pot:physical/colorCode",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "weight": {
+            "@id": "pot:physical/weight",
             "@nest": "data"
         },
         "ifcElementType": {
             "@id": "pot:categorization/ifcElementType",
             "@nest": "data"
         },
-        "weight": {
-            "@id": "pot:physical/weight",
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "serialNumber": {
+            "@id": "pot:identifier/serialNumber",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Organization.jsonld
+++ b/v1/Context/Identity/Organization.jsonld
@@ -17,25 +17,24 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
         "descriptionGeneral": {
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
         },
         "updatedAt": {
             "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
         },
         "name": {
-            "@id": "pot:identifier/name",
-            "@nest": "data"
+            "@id": "dli:name"
         },
         "categorizationOfficial": {
             "@id": "pot:categorization/categorizationOfficial",
@@ -45,20 +44,20 @@
             "@id": "pot:identifier/governmentPermanent",
             "@nest": "data"
         },
-        "taxVatCode": {
-            "@id": "pot:identifier/taxVatCode",
-            "@nest": "data"
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
+        "taxVatCode": {
+            "@id": "pot:identifier/taxVatCode",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Organization/LimitedCompany.jsonld
+++ b/v1/Context/Identity/Organization/LimitedCompany.jsonld
@@ -17,48 +17,47 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationOfficial": {
-            "@id": "pot:categorization/categorizationOfficial",
-            "@nest": "data"
-        },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
+        "descriptionGeneral": {
+            "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "taxVatCode": {
-            "@id": "pot:identifier/taxVatCode",
-            "@nest": "data"
-        },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "descriptionGeneral": {
-            "@id": "pot:description/descriptionGeneral",
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
         },
         "name": {
-            "@id": "pot:identifier/name",
+            "@id": "dli:name"
+        },
+        "categorizationOfficial": {
+            "@id": "pot:categorization/categorizationOfficial",
             "@nest": "data"
         },
         "governmentPermanent": {
             "@id": "pot:identifier/governmentPermanent",
             "@nest": "data"
         },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
         "status": {
             "@id": "pot:lifeCycle/status",
+            "@nest": "data"
+        },
+        "taxVatCode": {
+            "@id": "pot:identifier/taxVatCode",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Organization/LimitedCompany/HousingCooperative.jsonld
+++ b/v1/Context/Identity/Organization/LimitedCompany/HousingCooperative.jsonld
@@ -17,48 +17,47 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "categorizationOfficial": {
-            "@id": "pot:categorization/categorizationOfficial",
-            "@nest": "data"
-        },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
+        "descriptionGeneral": {
+            "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "taxVatCode": {
-            "@id": "pot:identifier/taxVatCode",
-            "@nest": "data"
-        },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
-        "descriptionGeneral": {
-            "@id": "pot:description/descriptionGeneral",
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
         },
         "name": {
-            "@id": "pot:identifier/name",
+            "@id": "dli:name"
+        },
+        "categorizationOfficial": {
+            "@id": "pot:categorization/categorizationOfficial",
             "@nest": "data"
         },
         "governmentPermanent": {
             "@id": "pot:identifier/governmentPermanent",
             "@nest": "data"
         },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
         "status": {
             "@id": "pot:lifeCycle/status",
+            "@nest": "data"
+        },
+        "taxVatCode": {
+            "@id": "pot:identifier/taxVatCode",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Room.jsonld
+++ b/v1/Context/Identity/Room.jsonld
@@ -17,80 +17,76 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
         },
         "categorizationOfficial": {
             "@id": "pot:categorization/categorizationOfficial",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
-            "@nest": "data"
-        },
-        "carbonDioxide": {
-            "@id": "pot:physical/carbonDioxide",
-            "@nest": "data"
-        },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "sizeAreaFloor": {
-            "@id": "pot:physical/sizeAreaFloor",
-            "@nest": "data"
-        },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "usageMain": {
-            "@id": "pot:categorization/usageMain",
-            "@nest": "data"
-        },
-        "sizeAreaLiving": {
-            "@id": "pot:physical/sizeAreaLiving",
-            "@nest": "data"
-        },
-        "temperature": {
-            "@id": "pot:physical/temperature",
-            "@nest": "data"
-        },
-        "createdBy": {
-            "@id": "dli:createdBy",
-            "@nest": "metadata"
-        },
-        "idlocal": {
-            "@id": "pot:identifier/idlocal",
-            "@nest": "data"
-        },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "descriptionGeneral": {
-            "@id": "pot:description/descriptionGeneral",
-            "@nest": "data"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
-        },
-        "name": {
-            "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
+        "idLocal": {
+            "@id": "pot:identifier/idLocal",
             "@nest": "data"
         },
         "sizeAreaLivingAudited": {
             "@id": "pot:physical/sizeAreaLivingAudited",
             "@nest": "data"
         },
+        "createdBy": {
+            "@id": "dli:createdBy",
+            "@nest": "metadata"
+        },
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "temperature": {
+            "@id": "pot:physical/temperature",
+            "@nest": "data"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
+            "@nest": "data"
+        },
+        "volume": {
+            "@id": "pot:physical/volume",
+            "@nest": "data"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "carbonDioxide": {
+            "@id": "pot:physical/carbonDioxide",
+            "@nest": "data"
+        },
+        "descriptionGeneral": {
+            "@id": "pot:description/descriptionGeneral",
+            "@nest": "data"
+        },
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
+        },
+        "sizeAreaLiving": {
+            "@id": "pot:physical/sizeAreaLiving",
+            "@nest": "data"
+        },
+        "name": {
+            "@id": "pot:identifier/name",
+            "@nest": "data"
+        },
         "quantity": {
             "@id": "pot:physical/quantity",
+            "@nest": "data"
+        },
+        "status": {
+            "@id": "pot:lifeCycle/status",
+            "@nest": "data"
+        },
+        "usageMain": {
+            "@id": "pot:categorization/usageMain",
             "@nest": "data"
         },
         "idOfficial": {
@@ -101,13 +97,17 @@
             "@id": "pot:physical/presence",
             "@nest": "data"
         },
-        "status": {
-            "@id": "pot:lifeCycle/status",
-            "@nest": "data"
-        },
         "additionalInformation": {
             "@id": "pot:description/additionalInformation",
             "@nest": "data"
+        },
+        "sizeAreaFloor": {
+            "@id": "pot:physical/sizeAreaFloor",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/Space.jsonld
+++ b/v1/Context/Identity/Space.jsonld
@@ -17,44 +17,36 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
         },
         "categorizationOfficial": {
             "@id": "pot:categorization/categorizationOfficial",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
+        "idLocal": {
+            "@id": "pot:identifier/idLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "sizeAreaFloor": {
-            "@id": "pot:physical/sizeAreaFloor",
-            "@nest": "data"
-        },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "usageMain": {
-            "@id": "pot:categorization/usageMain",
-            "@nest": "data"
-        },
-        "sizeAreaLiving": {
-            "@id": "pot:physical/sizeAreaLiving",
+        "sizeAreaLivingAudited": {
+            "@id": "pot:physical/sizeAreaLivingAudited",
             "@nest": "data"
         },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "idlocal": {
-            "@id": "pot:identifier/idlocal",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
+            "@nest": "data"
+        },
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -65,29 +57,40 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
+        "height": {
+            "@id": "pot:physical/height",
             "@nest": "data"
         },
-        "sizeAreaLivingAudited": {
-            "@id": "pot:physical/sizeAreaLivingAudited",
+        "sizeAreaLiving": {
+            "@id": "pot:physical/sizeAreaLiving",
+            "@nest": "data"
+        },
+        "name": {
+            "@id": "dli:name"
+        },
+        "status": {
+            "@id": "pot:lifeCycle/status",
+            "@nest": "data"
+        },
+        "usageMain": {
+            "@id": "pot:categorization/usageMain",
             "@nest": "data"
         },
         "idOfficial": {
             "@id": "pot:identifier/idOfficial",
             "@nest": "data"
         },
-        "status": {
-            "@id": "pot:lifeCycle/status",
-            "@nest": "data"
-        },
         "additionalInformation": {
             "@id": "pot:description/additionalInformation",
             "@nest": "data"
+        },
+        "sizeAreaFloor": {
+            "@id": "pot:physical/sizeAreaFloor",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/Space/Apartment.jsonld
+++ b/v1/Context/Identity/Space/Apartment.jsonld
@@ -17,52 +17,40 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "descriptionKitchen": {
-            "@id": "pot:description/descriptionKitchen",
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
         "categorizationOfficial": {
             "@id": "pot:categorization/categorizationOfficial",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
+        "idLocal": {
+            "@id": "pot:identifier/idLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "roomAmount": {
-            "@id": "pot:physical/roomAmount",
-            "@nest": "data"
-        },
-        "sizeAreaFloor": {
-            "@id": "pot:physical/sizeAreaFloor",
-            "@nest": "data"
-        },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "usageMain": {
-            "@id": "pot:categorization/usageMain",
-            "@nest": "data"
-        },
-        "sizeAreaLiving": {
-            "@id": "pot:physical/sizeAreaLiving",
+        "sizeAreaLivingAudited": {
+            "@id": "pot:physical/sizeAreaLivingAudited",
             "@nest": "data"
         },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "idlocal": {
-            "@id": "pot:identifier/idlocal",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
+            "@nest": "data"
+        },
+        "descriptionKitchen": {
+            "@id": "pot:description/descriptionKitchen",
+            "@nest": "data"
+        },
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -73,32 +61,44 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
+        },
+        "sizeAreaLiving": {
+            "@id": "pot:physical/sizeAreaLiving",
+            "@nest": "data"
         },
         "name": {
             "@id": "pot:identifier/name",
-            "@nest": "data"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
-            "@nest": "data"
-        },
-        "sizeAreaLivingAudited": {
-            "@id": "pot:physical/sizeAreaLivingAudited",
-            "@nest": "data"
-        },
-        "idOfficial": {
-            "@id": "pot:identifier/idOfficial",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
+        "usageMain": {
+            "@id": "pot:categorization/usageMain",
+            "@nest": "data"
+        },
+        "idOfficial": {
+            "@id": "pot:identifier/idOfficial",
+            "@nest": "data"
+        },
         "additionalInformation": {
             "@id": "pot:description/additionalInformation",
+            "@nest": "data"
+        },
+        "sizeAreaFloor": {
+            "@id": "pot:physical/sizeAreaFloor",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "roomAmount": {
+            "@id": "pot:physical/roomAmount",
             "@nest": "data"
         }
     }

--- a/v1/Context/Identity/Space/RealEstate.jsonld
+++ b/v1/Context/Identity/Space/RealEstate.jsonld
@@ -17,53 +17,41 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
         },
         "categorizationOfficial": {
             "@id": "pot:categorization/categorizationOfficial",
+            "@nest": "data"
+        },
+        "idLocal": {
+            "@id": "pot:identifier/idLocal",
+            "@nest": "data"
+        },
+        "idOfficialUnseparatedLand": {
+            "@id": "pot:identifier/idOfficialUnseparatedLand",
             "@nest": "data"
         },
         "areaTypeRegistration": {
             "@id": "pot:categorization/areaTypeRegistration",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
+        "locationUnseparatedLand": {
+            "@id": "pot:categorization/locationUnseparatedLand",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "sizeAreaFloor": {
-            "@id": "pot:physical/sizeAreaFloor",
-            "@nest": "data"
-        },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "usageMain": {
-            "@id": "pot:categorization/usageMain",
-            "@nest": "data"
-        },
-        "sizeAreaLiving": {
-            "@id": "pot:physical/sizeAreaLiving",
+        "sizeAreaLivingAudited": {
+            "@id": "pot:physical/sizeAreaLivingAudited",
             "@nest": "data"
         },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "idOfficialUnseparatedLand": {
-            "@id": "pot:identifier/idOfficialUnseparatedLand",
-            "@nest": "data"
-        },
-        "idlocal": {
-            "@id": "pot:identifier/idlocal",
-            "@nest": "data"
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
         },
         "controlCategory": {
             "@id": "pot:administration/controlCategory",
@@ -73,49 +61,61 @@
             "@id": "pot:physical/areaSquareMeter",
             "@nest": "data"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "descriptionGeneral": {
-            "@id": "pot:description/descriptionGeneral",
-            "@nest": "data"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
-        },
-        "name": {
-            "@id": "pot:identifier/name",
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
             "@nest": "data"
         },
         "volume": {
             "@id": "pot:physical/volume",
             "@nest": "data"
         },
-        "sizeAreaLivingAudited": {
-            "@id": "pot:physical/sizeAreaLivingAudited",
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "areaType": {
+            "@id": "pot:categorization/areaType",
             "@nest": "data"
         },
-        "idOfficial": {
-            "@id": "pot:identifier/idOfficial",
+        "descriptionGeneral": {
+            "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "locationUnseparatedLand": {
-            "@id": "pot:categorization/locationUnseparatedLand",
+        "height": {
+            "@id": "pot:physical/height",
+            "@nest": "data"
+        },
+        "sizeAreaLiving": {
+            "@id": "pot:physical/sizeAreaLiving",
+            "@nest": "data"
+        },
+        "name": {
+            "@id": "pot:identifier/name",
             "@nest": "data"
         },
         "status": {
             "@id": "pot:lifeCycle/status",
             "@nest": "data"
         },
-        "areaType": {
-            "@id": "pot:categorization/areaType",
+        "usageMain": {
+            "@id": "pot:categorization/usageMain",
+            "@nest": "data"
+        },
+        "idOfficial": {
+            "@id": "pot:identifier/idOfficial",
             "@nest": "data"
         },
         "additionalInformation": {
             "@id": "pot:description/additionalInformation",
             "@nest": "data"
+        },
+        "sizeAreaFloor": {
+            "@id": "pot:physical/sizeAreaFloor",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/Space/Zone.jsonld
+++ b/v1/Context/Identity/Space/Zone.jsonld
@@ -17,44 +17,36 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
+        "ifcGuid": {
+            "@id": "pot:identifier/ifcGuid",
+            "@nest": "data"
         },
         "categorizationOfficial": {
             "@id": "pot:categorization/categorizationOfficial",
             "@nest": "data"
         },
-        "categorizationLocal": {
-            "@id": "pot:categorization/categorizationLocal",
+        "idLocal": {
+            "@id": "pot:identifier/idLocal",
             "@nest": "data"
         },
-        "height": {
-            "@id": "pot:physical/height",
-            "@nest": "data"
-        },
-        "sizeAreaFloor": {
-            "@id": "pot:physical/sizeAreaFloor",
-            "@nest": "data"
-        },
-        "ifcGuid": {
-            "@id": "pot:identifier/ifcGuid",
-            "@nest": "data"
-        },
-        "usageMain": {
-            "@id": "pot:categorization/usageMain",
-            "@nest": "data"
-        },
-        "sizeAreaLiving": {
-            "@id": "pot:physical/sizeAreaLiving",
+        "sizeAreaLivingAudited": {
+            "@id": "pot:physical/sizeAreaLivingAudited",
             "@nest": "data"
         },
         "createdBy": {
             "@id": "dli:createdBy",
             "@nest": "metadata"
         },
-        "idlocal": {
-            "@id": "pot:identifier/idlocal",
+        "updatedAt": {
+            "@id": "dli:updatedAt",
+            "@nest": "metadata"
+        },
+        "categorizationLocal": {
+            "@id": "pot:categorization/categorizationLocal",
+            "@nest": "data"
+        },
+        "volume": {
+            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "updatedBy": {
@@ -65,29 +57,40 @@
             "@id": "pot:description/descriptionGeneral",
             "@nest": "data"
         },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
+        "height": {
+            "@id": "pot:physical/height",
             "@nest": "data"
         },
-        "sizeAreaLivingAudited": {
-            "@id": "pot:physical/sizeAreaLivingAudited",
+        "sizeAreaLiving": {
+            "@id": "pot:physical/sizeAreaLiving",
+            "@nest": "data"
+        },
+        "name": {
+            "@id": "dli:name"
+        },
+        "status": {
+            "@id": "pot:lifeCycle/status",
+            "@nest": "data"
+        },
+        "usageMain": {
+            "@id": "pot:categorization/usageMain",
             "@nest": "data"
         },
         "idOfficial": {
             "@id": "pot:identifier/idOfficial",
             "@nest": "data"
         },
-        "status": {
-            "@id": "pot:lifeCycle/status",
-            "@nest": "data"
-        },
         "additionalInformation": {
             "@id": "pot:description/additionalInformation",
             "@nest": "data"
+        },
+        "sizeAreaFloor": {
+            "@id": "pot:physical/sizeAreaFloor",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
         }
     }
 }

--- a/v1/Context/Identity/Storey.jsonld
+++ b/v1/Context/Identity/Storey.jsonld
@@ -1,8 +1,8 @@
 {
     "@context": {
         "@version": 1.1,
-        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Story",
-        "@classDefinition": "https://standards.oftrust.net/v1/ClassDefinitions/Story",
+        "@vocab": "https://standards.oftrust.net/v1/Vocabulary/Storey",
+        "@classDefinition": "https://standards.oftrust.net/v1/ClassDefinitions/Storey",
         "pot": {
             "@id": "https://standards.oftrust.net/v1/Vocabulary/",
             "@prefix": true
@@ -17,60 +17,63 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
         "descriptionGeneral": {
             "@id": "pot:description/descriptionGeneral",
-            "@nest": "data"
-        },
-        "updatedAt": {
-            "@id": "dli:updatedAt",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
-            "@nest": "metadata"
-        },
-        "volume": {
-            "@id": "pot:physical/volume",
             "@nest": "data"
         },
         "sizeAreaLivingAudited": {
             "@id": "pot:physical/sizeAreaLivingAudited",
             "@nest": "data"
         },
-        "sizeAreaLiving": {
-            "@id": "pot:physical/sizeAreaLiving",
-            "@nest": "data"
-        },
-        "thickness": {
-            "@id": "pot:physical/thickness",
-            "@nest": "data"
-        },
-        "idlocal": {
-            "@id": "pot:identifier/idlocal",
-            "@nest": "data"
-        },
-        "sizeArea": {
-            "@id": "pot:physical/sizeArea",
-            "@nest": "data"
-        },
-        "status": {
-            "@id": "pot:lifeCycle/status",
-            "@nest": "data"
-        },
         "createdBy": {
             "@id": "dli:createdBy",
+            "@nest": "metadata"
+        },
+        "updatedAt": {
+            "@id": "dli:updatedAt",
             "@nest": "metadata"
         },
         "ifcGuid": {
             "@id": "pot:identifier/ifcGuid",
             "@nest": "data"
         },
+        "sizeAreaLiving": {
+            "@id": "pot:physical/sizeAreaLiving",
+            "@nest": "data"
+        },
         "additionalInformation": {
             "@id": "pot:description/additionalInformation",
+            "@nest": "data"
+        },
+        "thickness": {
+            "@id": "pot:physical/thickness",
+            "@nest": "data"
+        },
+        "idLocal": {
+            "@id": "pot:identifier/idLocal",
+            "@nest": "data"
+        },
+        "name": {
+            "@id": "dli:name"
+        },
+        "sizeArea": {
+            "@id": "pot:physical/sizeArea",
+            "@nest": "data"
+        },
+        "volume": {
+            "@id": "pot:physical/volume",
+            "@nest": "data"
+        },
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
+            "@nest": "metadata"
+        },
+        "status": {
+            "@id": "pot:lifeCycle/status",
             "@nest": "data"
         }
     }

--- a/v1/Context/Link/BelongsTo.jsonld
+++ b/v1/Context/Link/BelongsTo.jsonld
@@ -17,12 +17,8 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
@@ -35,8 +31,12 @@
         "to": {
             "@id": "dli:to"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Link/LocatedAt.jsonld
+++ b/v1/Context/Link/LocatedAt.jsonld
@@ -17,12 +17,8 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
@@ -35,8 +31,12 @@
         "to": {
             "@id": "dli:to"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Link/ManagerAt.jsonld
+++ b/v1/Context/Link/ManagerAt.jsonld
@@ -17,12 +17,8 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
@@ -35,8 +31,12 @@
         "to": {
             "@id": "dli:to"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Link/ManagerOf.jsonld
+++ b/v1/Context/Link/ManagerOf.jsonld
@@ -17,12 +17,8 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
@@ -35,8 +31,12 @@
         "to": {
             "@id": "dli:to"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Link/OwnerAt.jsonld
+++ b/v1/Context/Link/OwnerAt.jsonld
@@ -17,12 +17,8 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
@@ -35,8 +31,12 @@
         "to": {
             "@id": "dli:to"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Link/OwnerOf.jsonld
+++ b/v1/Context/Link/OwnerOf.jsonld
@@ -17,12 +17,8 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
@@ -35,8 +31,12 @@
         "to": {
             "@id": "dli:to"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Context/Link/TenantAt.jsonld
+++ b/v1/Context/Link/TenantAt.jsonld
@@ -17,12 +17,8 @@
         "metadata": {
             "@id": "dli:metadata"
         },
-        "updatedBy": {
-            "@id": "dli:updatedBy",
-            "@nest": "metadata"
-        },
-        "createdAt": {
-            "@id": "dli:createdAt",
+        "createdBy": {
+            "@id": "dli:createdBy",
             "@nest": "metadata"
         },
         "updatedAt": {
@@ -35,8 +31,12 @@
         "to": {
             "@id": "dli:to"
         },
-        "createdBy": {
-            "@id": "dli:createdBy",
+        "updatedBy": {
+            "@id": "dli:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "dli:createdAt",
             "@nest": "metadata"
         }
     }

--- a/v1/Ontology/pot.jsonld
+++ b/v1/Ontology/pot.jsonld
@@ -126,6 +126,52 @@
     "owl:versionInfo": "DRAFT"
   },
   {
+    "@id": "pot:QrCode",
+    "@type": "pot:Class",
+    "subClassOf": "pot:Device",
+    "dli:label": [
+      {
+        "rdfs:label": {
+          "@language": "en-us",
+          "@value": "QR Code"
+        }
+      }
+    ],
+    "dli:comment": [
+      {
+        "rdfs:comment": {
+          "@language": "en-us",
+          "@value": "A machine-readable code consisting of an array of black and white squares, typically used for storing URLs or other information for reading by the camera on a smartphone"
+        }
+      }
+    ],
+    "vs:term_status": "unstable",
+    "owl:versionInfo": "DRAFT"
+  },
+  {
+    "@id": "pot:HumiditySensor",
+    "@type": "pot:Class",
+    "subClassOf": "pot:Sensor",
+    "dli:label": [
+      {
+        "rdfs:label": {
+          "@language": "en-us",
+          "@value": "Humidity Sensor"
+        }
+      }
+    ],
+    "dli:comment": [
+      {
+        "rdfs:comment": {
+          "@language": "en-us",
+          "@value": "A sensor which measures humidity"
+        }
+      }
+    ],
+    "vs:term_status": "unstable",
+    "owl:versionInfo": "DRAFT"
+  },
+  {
     "@id": "pot:Space",
     "@type": "pot:Class",
     "subClassOf": "dli:Virtual",
@@ -253,14 +299,14 @@
     "owl:versionInfo": "DRAFT"
   },
   {
-    "@id": "pot:Story",
+    "@id": "pot:Storey",
     "@type": "pot:Class",
     "subClassOf": "dli:BuiltEnvironment",
     "dli:label": [
       {
         "rdfs:label": {
           "@language": "en-us",
-          "@value": "Story"
+          "@value": "Storey"
         }
       }
     ],
@@ -268,7 +314,7 @@
       {
         "rdfs:comment": {
           "@language": "en-us",
-          "@value": "A Story is the bottom surface of a room or vehicle (also called floor)"
+          "@value": "A Storey is the bottom surface of a room or vehicle (also called floor)"
         }
       }
     ],
@@ -912,7 +958,7 @@
       {
         "rdfs:comment": {
           "@language": "en-us",
-          "@value": "Floor is composed of the structural objects which are built on top of story"
+          "@value": "Floor is composed of the structural objects which are built on top of storey"
         }
       }
     ],
@@ -1096,7 +1142,7 @@
       {
         "rdfs:comment": {
           "@language": "en-us",
-          "@value": "A set of steps leading from one story of a building to another"
+          "@value": "A set of steps leading from one storey of a building to another"
         }
       }
     ],
@@ -1509,29 +1555,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "IFC element name"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "IFC elementti nimi"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "IFC element name"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "IFC elementti nimi"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -1539,15 +1569,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "IFC standard element name"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "IFC standard element name"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "xsd:restriction": {
@@ -1576,29 +1598,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "IFC element type"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "IFC elementti tyyppi"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "IFC element type"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "IFC elementti tyyppi"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -1606,15 +1612,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "IFC standard element type"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "IFC standard element type"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "xsd:restriction": {
@@ -1687,34 +1685,6 @@
       {
         "rdfs:label": {
           "@language": "en-us",
-          "@value": "Space type - local"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Tilatyyppi - paikallinen"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Space type - local"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Tilatyyppi - paikallinen"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
           "@value": "Type name given locally"
         },
         "dli:domain": "pot:BuildingElement"
@@ -1739,26 +1709,24 @@
           "@value": "Lokaali tyypitys"
         },
         "dli:domain": "pot:Device"
+      },
+      {
+        "rdfs:label": {
+          "@language": "en-us",
+          "@value": "Space type - local"
+        }
+      },
+      {
+        "rdfs:label": {
+          "@language": "fi-fi",
+          "@value": "Tilatyyppi - paikallinen"
+        }
       }
     ],
     "dli:comment": [
       {
         "rdfs:comment": {
           "@language": "en-us",
-          "@value": "Space type name derived from local categorization naming"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Space type name derived from local categorization naming"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
           "@value": "Categorisation name given locally"
         },
         "dli:domain": "pot:BuildingElement"
@@ -1769,6 +1737,12 @@
           "@value": "Categorisation name given locally"
         },
         "dli:domain": "pot:Device"
+      },
+      {
+        "rdfs:comment": {
+          "@language": "en-us",
+          "@value": "Space type name derived from local categorization naming"
+        }
       }
     ],
     "xsd:restriction": {
@@ -1858,29 +1832,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Space type - official"
-        },
-        "dli:domain": "pot:Room"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Tilatyyppi - viranomainen"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Space type - official"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Tilatyyppi - viranomainen"
-        },
-        "dli:domain": "pot:Space"
+        }
       }
     ],
     "dli:comment": [
@@ -1895,15 +1853,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "Space type name derived from official categorization naming"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Space type name derived from official categorization naming"
-        },
-        "dli:domain": "pot:Space"
+        }
       }
     ],
     "xsd:restriction": {
@@ -1933,43 +1883,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Main usage purpose"
-        },
-        "dli:domain": "pot:RealEstate"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Käyttötarkoitus"
-        },
-        "dli:domain": "pot:RealEstate"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Main usage purpose"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Käyttötarkoitus"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Main usage purpose"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Käyttötarkoitus"
-        },
-        "dli:domain": "pot:Space"
+        }
       }
     ],
     "dli:comment": [
@@ -1977,22 +1897,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "Main usage purpose"
-        },
-        "dli:domain": "pot:RealEstate"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Main usage purpose"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Main usage purpose"
-        },
-        "dli:domain": "pot:Space"
+        }
       }
     ],
     "xsd:restriction": {
@@ -2133,16 +2038,16 @@
       {
         "rdfs:label": {
           "@language": "en-us",
-          "@value": "Story description"
+          "@value": "Storey description"
         },
-        "dli:domain": "pot:Story"
+        "dli:domain": "pot:Storey"
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Kerroksen kuvaus"
         },
-        "dli:domain": "pot:Story"
+        "dli:domain": "pot:Storey"
       }
     ],
     "dli:comment": [
@@ -2205,9 +2110,9 @@
       {
         "rdfs:comment": {
           "@language": "en-us",
-          "@value": "Description of the story"
+          "@value": "Description of the storey"
         },
-        "dli:domain": "pot:Story"
+        "dli:domain": "pot:Storey"
       }
     ],
     "xsd:restriction": {
@@ -2223,7 +2128,7 @@
       "pot:RealEstate",
       "pot:Room",
       "pot:Space",
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:string"
@@ -2243,43 +2148,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Additional information"
-        },
-        "dli:domain": "pot:Room"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Lisätiedot"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Additional information"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Lisätiedot"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Additional information"
-        },
-        "dli:domain": "pot:Story"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Lisätiedot"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "dli:comment": [
@@ -2287,22 +2162,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "Additional information"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Additional information"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Additional information"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "xsd:restriction": {
@@ -2312,7 +2172,7 @@
     "domain": [
       "pot:Room",
       "pot:Space",
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:string"
@@ -2377,29 +2237,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Local code"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Paikallinen koodi"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Local code"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Paikallinen koodi"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -2489,113 +2333,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Building"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Building"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Organization"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Organization"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:RealEstate"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:RealEstate"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Story"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "IFC GUID"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "dli:comment": [
@@ -2603,57 +2347,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "IFC standard based Globally Unique Identifier"
-        },
-        "dli:domain": "pot:Building"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "IFC standard based Globally Unique Identifier"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "IFC standard based Globally Unique Identifier"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "IFC standard based Globally Unique Identifier"
-        },
-        "dli:domain": "pot:Organization"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "IFC standard based Globally Unique Identifier"
-        },
-        "dli:domain": "pot:RealEstate"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "IFC standard based Globally Unique Identifier"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "IFC standard based Globally Unique Identifier"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "IFC standard based Globally Unique Identifier"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "xsd:restriction": {
@@ -2668,7 +2362,7 @@
       "pot:RealEstate",
       "pot:Room",
       "pot:Space",
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:string"
@@ -2722,7 +2416,7 @@
     "owl:versionInfo": "DRAFT"
   },
   {
-    "@id": "pot:idlocal",
+    "@id": "pot:idLocal",
     "@type": "rdf:Property",
     "subPropertyOf": "pot:identifier",
     "dli:nested": "data",
@@ -2747,43 +2441,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Local Id"
-        },
-        "dli:domain": "pot:Room"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Paikallinen tunniste"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Local Id"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Paikallinen tunniste"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Local Id"
-        },
-        "dli:domain": "pot:Story"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Paikallinen tunniste"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "dli:comment": [
@@ -2797,23 +2461,15 @@
       {
         "rdfs:comment": {
           "@language": "en-us",
-          "@value": "Locally given identifier for the space"
+          "@value": "Locally given identifier for the storey"
         },
-        "dli:domain": "pot:Room"
+        "dli:domain": "pot:Storey"
       },
       {
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "Locally given identifier for the space"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Locally given identifier for the story"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "xsd:restriction": {
@@ -2824,7 +2480,7 @@
       "pot:Case",
       "pot:Room",
       "pot:Space",
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:string"
@@ -2853,34 +2509,6 @@
           "@value": "Rakennuksen nimi"
         },
         "dli:domain": "pot:Building"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Local name"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Paikallinen nimi"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Local name"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Paikallinen nimi"
-        },
-        "dli:domain": "pot:Device"
       },
       {
         "rdfs:label": {
@@ -2937,6 +2565,18 @@
           "@value": "Huoneen nimi"
         },
         "dli:domain": "pot:Room"
+      },
+      {
+        "rdfs:label": {
+          "@language": "en-us",
+          "@value": "Local name"
+        }
+      },
+      {
+        "rdfs:label": {
+          "@language": "fi-fi",
+          "@value": "Paikallinen nimi"
+        }
       }
     ],
     "dli:comment": [
@@ -3080,29 +2720,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Official Id"
-        },
-        "dli:domain": "pot:Room"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Viranomaisen tunniste"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Official Id"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Viranomaisen tunniste"
-        },
-        "dli:domain": "pot:Space"
+        }
       }
     ],
     "dli:comment": [
@@ -3511,34 +3135,6 @@
       {
         "rdfs:label": {
           "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Building"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Elinkaari - Status"
-        },
-        "dli:domain": "pot:Building"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Elinkaari - Status"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
           "@value": "Case status"
         },
         "dli:domain": "pot:Case"
@@ -3554,99 +3150,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Device"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Elinkaari - Status"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Organization"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Elinkaari - Status"
-        },
-        "dli:domain": "pot:Organization"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:RealEstate"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Elinkaari - Status"
-        },
-        "dli:domain": "pot:RealEstate"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Elinkaari - Status"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Elinkaari - Status"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Elinkaari - Status"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Story"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Elinkaari - Status"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "dli:comment": [
@@ -3660,13 +3170,6 @@
       {
         "rdfs:comment": {
           "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
           "@value": "Case state"
         },
         "dli:domain": "pot:Case"
@@ -3675,50 +3178,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Organization"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:RealEstate"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Life cycle status"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "xsd:restriction": {
@@ -3735,7 +3195,7 @@
       "pot:Room",
       "pot:Space",
       "pot:Space",
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:string"
@@ -3755,29 +3215,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Area - gross"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Pinta-ala - brutto"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Area - gross"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Pinta-ala - brutto"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -3821,29 +3265,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Area - net"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Pinta-ala - netto"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Area - net"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Pinta-ala - netto"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -4063,29 +3491,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Color code"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Väritunnus"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Color code"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Väritunnus"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -4130,29 +3542,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Color"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Väri"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Color"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Väri"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -4241,71 +3637,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Height"
-        },
-        "dli:domain": "pot:Building"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Korkeus"
-        },
-        "dli:domain": "pot:Building"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Height"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Korkeus"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Height"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Korkeus"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Height"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Korkeus"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Height"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Korkeus"
-        },
-        "dli:domain": "pot:Space"
+        }
       }
     ],
     "dli:comment": [
@@ -4373,29 +3711,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Length"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Pituus"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Length"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Pituus"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -4615,32 +3937,32 @@
       {
         "rdfs:label": {
           "@language": "en-us",
-          "@value": "Story area size"
+          "@value": "Storey area size"
         },
-        "dli:domain": "pot:Story"
+        "dli:domain": "pot:Storey"
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Pinta-ala/Kerrosala"
         },
-        "dli:domain": "pot:Story"
+        "dli:domain": "pot:Storey"
       }
     ],
     "dli:comment": [
       {
         "rdfs:comment": {
           "@language": "en-us",
-          "@value": "Area of the story"
+          "@value": "Area of the storey"
         },
-        "dli:domain": "pot:Story"
+        "dli:domain": "pot:Storey"
       }
     ],
     "xsd:restriction": {
       "xsd:base": "xsd:decimal"
     },
     "domain": [
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:decimal"
@@ -4660,29 +3982,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Floor area size"
-        },
-        "dli:domain": "pot:Room"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Pinta-ala/Kerrosala"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Floor area size"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Pinta-ala/Kerrosala"
-        },
-        "dli:domain": "pot:Space"
+        }
       }
     ],
     "dli:comment": [
@@ -4690,15 +3996,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "Area of the space"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Area of the space"
-        },
-        "dli:domain": "pot:Space"
+        }
       }
     ],
     "xsd:restriction": {
@@ -4726,43 +4024,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Living area size"
-        },
-        "dli:domain": "pot:Room"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Huoneistoala/Asuinpinta-ala"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Living area size"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Huoneistoala/Asuinpinta-ala"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Living area size"
-        },
-        "dli:domain": "pot:Story"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Huoneistoala/Asuinpinta-ala"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "dli:comment": [
@@ -4777,15 +4045,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "Size of area suitable for, or used for, living"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Size of area suitable for, or used for, living"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "xsd:restriction": {
@@ -4794,7 +4054,7 @@
     "domain": [
       "pot:Room",
       "pot:Space",
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:decimal"
@@ -4814,43 +4074,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Audited living area size"
-        },
-        "dli:domain": "pot:Room"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Asuinpinta-ala - tarkistusmitattu"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Audited living area size"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Asuinpinta-ala - tarkistusmitattu"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Audited living area size"
-        },
-        "dli:domain": "pot:Story"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Asuinpinta-ala - tarkistusmitattu"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "dli:comment": [
@@ -4858,22 +4088,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "Size of audited area suitable for, or used for, living"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Size of audited area suitable for, or used for, living"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
-          "@value": "Size of audited area suitable for, or used for, living"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "xsd:restriction": {
@@ -4882,7 +4097,7 @@
     "domain": [
       "pot:Room",
       "pot:Space",
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:decimal"
@@ -4946,43 +4161,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Thickness"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Paksuus"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Thickness"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Paksuus"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Thickness"
-        },
-        "dli:domain": "pot:Story"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Paksuus"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "dli:comment": [
@@ -5005,7 +4190,7 @@
           "@language": "en-us",
           "@value": "Thickness of the object"
         },
-        "dli:domain": "pot:Story"
+        "dli:domain": "pot:Storey"
       }
     ],
     "xsd:restriction": {
@@ -5014,7 +4199,7 @@
     "domain": [
       "pot:BuildingElement",
       "pot:Device",
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:decimal"
@@ -5034,29 +4219,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Weight"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Paino"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Weight"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Paino"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -5100,29 +4269,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Width"
-        },
-        "dli:domain": "pot:BuildingElement"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Leveys"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Width"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Leveys"
-        },
-        "dli:domain": "pot:Device"
+        }
       }
     ],
     "dli:comment": [
@@ -5166,85 +4319,13 @@
         "rdfs:label": {
           "@language": "en-us",
           "@value": "Volume"
-        },
-        "dli:domain": "pot:Building"
+        }
       },
       {
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Tilavuus"
-        },
-        "dli:domain": "pot:Building"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Volume"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Tilavuus"
-        },
-        "dli:domain": "pot:BuildingElement"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Volume"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Tilavuus"
-        },
-        "dli:domain": "pot:Device"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Volume"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Tilavuus"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Volume"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Tilavuus"
-        },
-        "dli:domain": "pot:Space"
-      },
-      {
-        "rdfs:label": {
-          "@language": "en-us",
-          "@value": "Volume"
-        },
-        "dli:domain": "pot:Story"
-      },
-      {
-        "rdfs:label": {
-          "@language": "fi-fi",
-          "@value": "Tilavuus"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "dli:comment": [
@@ -5272,13 +4353,6 @@
       {
         "rdfs:comment": {
           "@language": "en-us",
-          "@value": "Volume of the object"
-        },
-        "dli:domain": "pot:Room"
-      },
-      {
-        "rdfs:comment": {
-          "@language": "en-us",
           "@value": "Volume of the space"
         },
         "dli:domain": "pot:Space"
@@ -5287,8 +4361,7 @@
         "rdfs:comment": {
           "@language": "en-us",
           "@value": "Volume of the object"
-        },
-        "dli:domain": "pot:Story"
+        }
       }
     ],
     "xsd:restriction": {
@@ -5300,7 +4373,7 @@
       "pot:Device",
       "pot:Room",
       "pot:Space",
-      "pot:Story"
+      "pot:Storey"
     ],
     "range": [
       "xsd:decimal"
@@ -5523,51 +4596,13 @@
       "pot:Class",
       "pot:Space",
       "pot:Organization",
-      "pot:LimitedCompany",
-      "pot:HousingCooperative",
       "pot:Building",
-      "pot:Story",
+      "pot:Storey",
       "pot:Room",
       "pot:BuildingSystems",
-      "pot:HeatingSystem",
-      "pot:VentilationSystem",
-      "pot:AirConditioningSystem",
-      "pot:SewageSystem",
-      "pot:PowerSystem",
-      "pot:SecuritySystem",
-      "pot:LightingSystem",
-      "pot:BuildingAutomationSystem",
-      "pot:VideoSurveillanceSystem",
       "pot:Device",
-      "pot:Sensor",
-      "pot:TemperatureSensor",
-      "pot:CarbonDioxideSensor",
-      "pot:QuantitySensor",
-      "pot:PresenceSensor",
-      "pot:AirFilteringDevice",
-      "pot:AirConditioningDevice",
-      "pot:VentilationDevice",
-      "pot:HeatingDevice",
-      "pot:Radiator",
-      "pot:PowerDevice",
-      "pot:WaterDevice",
-      "pot:Faucet",
-      "pot:SecurityDevice",
       "pot:BuildingElement",
-      "pot:Floor",
-      "pot:Column",
-      "pot:Slab",
-      "pot:Beam",
-      "pot:Wall",
-      "pot:Window",
-      "pot:Door",
-      "pot:CurtainWall",
-      "pot:Stair",
-      "pot:Roof",
       "pot:Case",
-      "pot:RealEstate",
-      "pot:Apartment",
-      "pot:Zone",
       "pot:TenantAt",
       "pot:OwnerOf",
       "pot:OwnerAt",
@@ -5617,51 +4652,13 @@
       "pot:Class",
       "pot:Space",
       "pot:Organization",
-      "pot:LimitedCompany",
-      "pot:HousingCooperative",
       "pot:Building",
-      "pot:Story",
+      "pot:Storey",
       "pot:Room",
       "pot:BuildingSystems",
-      "pot:HeatingSystem",
-      "pot:VentilationSystem",
-      "pot:AirConditioningSystem",
-      "pot:SewageSystem",
-      "pot:PowerSystem",
-      "pot:SecuritySystem",
-      "pot:LightingSystem",
-      "pot:BuildingAutomationSystem",
-      "pot:VideoSurveillanceSystem",
       "pot:Device",
-      "pot:Sensor",
-      "pot:TemperatureSensor",
-      "pot:CarbonDioxideSensor",
-      "pot:QuantitySensor",
-      "pot:PresenceSensor",
-      "pot:AirFilteringDevice",
-      "pot:AirConditioningDevice",
-      "pot:VentilationDevice",
-      "pot:HeatingDevice",
-      "pot:Radiator",
-      "pot:PowerDevice",
-      "pot:WaterDevice",
-      "pot:Faucet",
-      "pot:SecurityDevice",
       "pot:BuildingElement",
-      "pot:Floor",
-      "pot:Column",
-      "pot:Slab",
-      "pot:Beam",
-      "pot:Wall",
-      "pot:Window",
-      "pot:Door",
-      "pot:CurtainWall",
-      "pot:Stair",
-      "pot:Roof",
       "pot:Case",
-      "pot:RealEstate",
-      "pot:Apartment",
-      "pot:Zone",
       "pot:TenantAt",
       "pot:OwnerOf",
       "pot:OwnerAt",
@@ -5711,51 +4708,13 @@
       "pot:Class",
       "pot:Space",
       "pot:Organization",
-      "pot:LimitedCompany",
-      "pot:HousingCooperative",
       "pot:Building",
-      "pot:Story",
+      "pot:Storey",
       "pot:Room",
       "pot:BuildingSystems",
-      "pot:HeatingSystem",
-      "pot:VentilationSystem",
-      "pot:AirConditioningSystem",
-      "pot:SewageSystem",
-      "pot:PowerSystem",
-      "pot:SecuritySystem",
-      "pot:LightingSystem",
-      "pot:BuildingAutomationSystem",
-      "pot:VideoSurveillanceSystem",
       "pot:Device",
-      "pot:Sensor",
-      "pot:TemperatureSensor",
-      "pot:CarbonDioxideSensor",
-      "pot:QuantitySensor",
-      "pot:PresenceSensor",
-      "pot:AirFilteringDevice",
-      "pot:AirConditioningDevice",
-      "pot:VentilationDevice",
-      "pot:HeatingDevice",
-      "pot:Radiator",
-      "pot:PowerDevice",
-      "pot:WaterDevice",
-      "pot:Faucet",
-      "pot:SecurityDevice",
       "pot:BuildingElement",
-      "pot:Floor",
-      "pot:Column",
-      "pot:Slab",
-      "pot:Beam",
-      "pot:Wall",
-      "pot:Window",
-      "pot:Door",
-      "pot:CurtainWall",
-      "pot:Stair",
-      "pot:Roof",
       "pot:Case",
-      "pot:RealEstate",
-      "pot:Apartment",
-      "pot:Zone",
       "pot:TenantAt",
       "pot:OwnerOf",
       "pot:OwnerAt",
@@ -5805,51 +4764,13 @@
       "pot:Class",
       "pot:Space",
       "pot:Organization",
-      "pot:LimitedCompany",
-      "pot:HousingCooperative",
       "pot:Building",
-      "pot:Story",
+      "pot:Storey",
       "pot:Room",
       "pot:BuildingSystems",
-      "pot:HeatingSystem",
-      "pot:VentilationSystem",
-      "pot:AirConditioningSystem",
-      "pot:SewageSystem",
-      "pot:PowerSystem",
-      "pot:SecuritySystem",
-      "pot:LightingSystem",
-      "pot:BuildingAutomationSystem",
-      "pot:VideoSurveillanceSystem",
       "pot:Device",
-      "pot:Sensor",
-      "pot:TemperatureSensor",
-      "pot:CarbonDioxideSensor",
-      "pot:QuantitySensor",
-      "pot:PresenceSensor",
-      "pot:AirFilteringDevice",
-      "pot:AirConditioningDevice",
-      "pot:VentilationDevice",
-      "pot:HeatingDevice",
-      "pot:Radiator",
-      "pot:PowerDevice",
-      "pot:WaterDevice",
-      "pot:Faucet",
-      "pot:SecurityDevice",
       "pot:BuildingElement",
-      "pot:Floor",
-      "pot:Column",
-      "pot:Slab",
-      "pot:Beam",
-      "pot:Wall",
-      "pot:Window",
-      "pot:Door",
-      "pot:CurtainWall",
-      "pot:Stair",
-      "pot:Roof",
       "pot:Case",
-      "pot:RealEstate",
-      "pot:Apartment",
-      "pot:Zone",
       "pot:TenantAt",
       "pot:OwnerOf",
       "pot:OwnerAt",
@@ -5892,7 +4813,18 @@
     "xsd:restriction": {
       "xsd:base": "xsd:string"
     },
-    "domain": [],
+    "domain": [
+      "pot:Space",
+      "pot:Organization",
+      "pot:Building",
+      "pot:Storey",
+      "pot:Room",
+      "pot:BuildingSystems",
+      "pot:Device",
+      "pot:BuildingElement",
+      "pot:Case",
+      "dli:SupportedAttribute"
+    ],
     "range": [
       "xsd:string"
     ],
@@ -5929,51 +4861,13 @@
       "pot:Class",
       "pot:Space",
       "pot:Organization",
-      "pot:LimitedCompany",
-      "pot:HousingCooperative",
       "pot:Building",
-      "pot:Story",
+      "pot:Storey",
       "pot:Room",
       "pot:BuildingSystems",
-      "pot:HeatingSystem",
-      "pot:VentilationSystem",
-      "pot:AirConditioningSystem",
-      "pot:SewageSystem",
-      "pot:PowerSystem",
-      "pot:SecuritySystem",
-      "pot:LightingSystem",
-      "pot:BuildingAutomationSystem",
-      "pot:VideoSurveillanceSystem",
       "pot:Device",
-      "pot:Sensor",
-      "pot:TemperatureSensor",
-      "pot:CarbonDioxideSensor",
-      "pot:QuantitySensor",
-      "pot:PresenceSensor",
-      "pot:AirFilteringDevice",
-      "pot:AirConditioningDevice",
-      "pot:VentilationDevice",
-      "pot:HeatingDevice",
-      "pot:Radiator",
-      "pot:PowerDevice",
-      "pot:WaterDevice",
-      "pot:Faucet",
-      "pot:SecurityDevice",
       "pot:BuildingElement",
-      "pot:Floor",
-      "pot:Column",
-      "pot:Slab",
-      "pot:Beam",
-      "pot:Wall",
-      "pot:Window",
-      "pot:Door",
-      "pot:CurtainWall",
-      "pot:Stair",
-      "pot:Roof",
       "pot:Case",
-      "pot:RealEstate",
-      "pot:Apartment",
-      "pot:Zone",
       "pot:TenantAt",
       "pot:OwnerOf",
       "pot:OwnerAt",
@@ -6016,51 +4910,13 @@
       "pot:Class",
       "pot:Space",
       "pot:Organization",
-      "pot:LimitedCompany",
-      "pot:HousingCooperative",
       "pot:Building",
-      "pot:Story",
+      "pot:Storey",
       "pot:Room",
       "pot:BuildingSystems",
-      "pot:HeatingSystem",
-      "pot:VentilationSystem",
-      "pot:AirConditioningSystem",
-      "pot:SewageSystem",
-      "pot:PowerSystem",
-      "pot:SecuritySystem",
-      "pot:LightingSystem",
-      "pot:BuildingAutomationSystem",
-      "pot:VideoSurveillanceSystem",
       "pot:Device",
-      "pot:Sensor",
-      "pot:TemperatureSensor",
-      "pot:CarbonDioxideSensor",
-      "pot:QuantitySensor",
-      "pot:PresenceSensor",
-      "pot:AirFilteringDevice",
-      "pot:AirConditioningDevice",
-      "pot:VentilationDevice",
-      "pot:HeatingDevice",
-      "pot:Radiator",
-      "pot:PowerDevice",
-      "pot:WaterDevice",
-      "pot:Faucet",
-      "pot:SecurityDevice",
       "pot:BuildingElement",
-      "pot:Floor",
-      "pot:Column",
-      "pot:Slab",
-      "pot:Beam",
-      "pot:Wall",
-      "pot:Window",
-      "pot:Door",
-      "pot:CurtainWall",
-      "pot:Stair",
-      "pot:Roof",
       "pot:Case",
-      "pot:RealEstate",
-      "pot:Apartment",
-      "pot:Zone",
       "pot:TenantAt",
       "pot:OwnerOf",
       "pot:OwnerAt",
@@ -6199,7 +5055,9 @@
       "xsd:base": "xsd:string",
       "xsd:maxLength": 500
     },
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "range": [
       "xsd:string"
     ],
@@ -6216,7 +5074,9 @@
       "xsd:base": "xsd:string",
       "xsd:maxLength": 500
     },
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "range": [
       "xsd:string"
     ],
@@ -6233,7 +5093,9 @@
       "xsd:base": "xsd:string",
       "xsd:maxLength": 500
     },
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "range": [
       "xsd:string"
     ],
@@ -6249,7 +5111,9 @@
       "xsd:base": "xsd:string",
       "xsd:maxLength": 500
     },
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "range": [
       "xsd:string"
     ],
@@ -6265,7 +5129,9 @@
       "xsd:base": "xsd:string",
       "xsd:maxLength": 500
     },
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "range": [
       "xsd:boolean"
     ],
@@ -6281,7 +5147,9 @@
       "xsd:base": "xsd:string",
       "xsd:maxLength": 500
     },
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "range": [
       "xsd:boolean"
     ],
@@ -6297,7 +5165,9 @@
       "xsd:base": "xsd:string",
       "xsd:maxLength": 500
     },
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "range": [
       "xsd:string"
     ],
@@ -6314,7 +5184,8 @@
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Tuetut luokat"
-        }
+        },
+        "dli:domain": "dli:SupportedClass"
       }
     ],
     "dli:comment": [
@@ -6322,14 +5193,17 @@
         "rdfs:comment": {
           "@language": "fi-fi",
           "@value": "Luokat jotka tiedetään kuuluvan identiteettiin"
-        }
+        },
+        "dli:domain": "dli:SupportedClass"
       }
     ],
     "xsd:restriction": {
       "xsd:base": "xsd:string",
       "xsd:maxLength": 500
     },
-    "domain": [],
+    "domain": [
+      "dli:SupportedClass"
+    ],
     "range": [
       "xsd:string"
     ],
@@ -6346,7 +5220,8 @@
         "rdfs:label": {
           "@language": "fi-fi",
           "@value": "Tuetut attribuutit"
-        }
+        },
+        "dli:domain": "dli:SupportedAttribute"
       }
     ],
     "dli:comment": [
@@ -6354,14 +5229,17 @@
         "rdfs:comment": {
           "@language": "fi-fi",
           "@value": "Attribuutit jotka tiedetään liittyvän identiteettiin"
-        }
+        },
+        "dli:domain": "dli:SupportedAttribute"
       }
     ],
     "xsd:restriction": {
       "xsd:base": "xsd:string",
       "xsd:maxLength": 500
     },
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "range": [
       "xsd:string"
     ],
@@ -6373,7 +5251,9 @@
     "@type": "rdf:Property",
     "dli:required": false,
     "dli:readonly": false,
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "vs:term_status": "unstable",
     "owl:versionInfo": "DRAFT"
   },
@@ -6382,7 +5262,9 @@
     "@type": "rdf:Property",
     "dli:required": false,
     "dli:readonly": false,
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "vs:term_status": "unstable",
     "owl:versionInfo": "DRAFT"
   },
@@ -6391,7 +5273,9 @@
     "@type": "rdf:Property",
     "dli:required": false,
     "dli:readonly": false,
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "vs:term_status": "unstable",
     "owl:versionInfo": "DRAFT"
   },
@@ -6400,7 +5284,9 @@
     "@type": "rdf:Property",
     "dli:required": false,
     "dli:readonly": false,
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "vs:term_status": "unstable",
     "owl:versionInfo": "DRAFT"
   },
@@ -6409,7 +5295,9 @@
     "@type": "rdf:Property",
     "dli:required": false,
     "dli:readonly": false,
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "vs:term_status": "unstable",
     "owl:versionInfo": "DRAFT"
   },
@@ -6418,7 +5306,9 @@
     "@type": "rdf:Property",
     "dli:required": false,
     "dli:readonly": false,
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "vs:term_status": "unstable",
     "owl:versionInfo": "DRAFT"
   },
@@ -6427,7 +5317,9 @@
     "@type": "rdf:Property",
     "dli:required": false,
     "dli:readonly": false,
-    "domain": [],
+    "domain": [
+      "dli:SupportedAttribute"
+    ],
     "vs:term_status": "unstable",
     "owl:versionInfo": "DRAFT"
   }

--- a/v1/Vocabulary.jsonld
+++ b/v1/Vocabulary.jsonld
@@ -36,30 +36,6 @@
             ]
         }
     },
-    "Device": {
-        "@id": "pot:Device",
-        "@type": "pot:Class",
-        "subClassOf": "dli:Thing",
-        "rdfs:label": {
-            "en-us": "Device"
-        }
-    },
-    "Building": {
-        "@id": "pot:Building",
-        "@type": "pot:Class",
-        "subClassOf": "dli:BuiltEnvironment",
-        "rdfs:label": {
-            "en-us": "Building"
-        }
-    },
-    "TenantAt": {
-        "@id": "pot:TenantAt",
-        "@type": "pot:Class",
-        "subClassOf": "dli:Role",
-        "rdfs:label": {
-            "en-us": "Tenant at"
-        }
-    },
     "Space": {
         "@id": "pot:Space",
         "@type": "pot:Class",
@@ -67,94 +43,6 @@
         "rdfs:label": {
             "fi-fi": "2D tai 3D tila",
             "en-us": "Spatial area or volume"
-        }
-    },
-    "OwnerOf": {
-        "@id": "pot:OwnerOf",
-        "@type": "pot:Class",
-        "subClassOf": "dli:Role",
-        "rdfs:label": {
-            "en-us": "Owner of"
-        }
-    },
-    "Room": {
-        "@id": "pot:Room",
-        "@type": "pot:Class",
-        "subClassOf": "dli:BuiltEnvironment",
-        "rdfs:label": {
-            "en-us": "Room"
-        }
-    },
-    "LocatedAt": {
-        "@id": "pot:LocatedAt",
-        "@type": "pot:Class",
-        "subClassOf": "dli:Role",
-        "rdfs:label": {
-            "en-us": "Located at"
-        }
-    },
-    "Organization": {
-        "@id": "pot:Organization",
-        "@type": "pot:Class",
-        "subClassOf": "dli:Group",
-        "rdfs:label": {
-            "en-us": "Organization"
-        }
-    },
-    "BuildingSystems": {
-        "@id": "pot:BuildingSystems",
-        "@type": "pot:Class",
-        "subClassOf": "dli:System",
-        "rdfs:label": {
-            "en-us": "Building Systems"
-        }
-    },
-    "Case": {
-        "@id": "pot:Case",
-        "@type": "pot:Class",
-        "subClassOf": "dli:Virtual",
-        "rdfs:label": {
-            "en-us": "Case"
-        }
-    },
-    "Story": {
-        "@id": "pot:Story",
-        "@type": "pot:Class",
-        "subClassOf": "dli:BuiltEnvironment",
-        "rdfs:label": {
-            "en-us": "Story"
-        }
-    },
-    "BelongsTo": {
-        "@id": "pot:BelongsTo",
-        "@type": "pot:Class",
-        "subClassOf": "dli:Role",
-        "rdfs:label": {
-            "en-us": "Belongs to"
-        }
-    },
-    "Class": {
-        "@id": "pot:Class",
-        "@type": "pot:Class",
-        "subClassOf": "rdfs:Class",
-        "rdfs:label": {
-            "en-us": "PoT Class"
-        }
-    },
-    "BuildingElement": {
-        "@id": "pot:BuildingElement",
-        "@type": "pot:Class",
-        "subClassOf": "dli:Thing",
-        "rdfs:label": {
-            "en-us": "Building Element"
-        }
-    },
-    "ManagerOf": {
-        "@id": "pot:ManagerOf",
-        "@type": "pot:Class",
-        "subClassOf": "dli:Role",
-        "rdfs:label": {
-            "en-us": "Manager of"
         }
     },
     "ManagerAt": {
@@ -165,12 +53,124 @@
             "en-us": "Manager at"
         }
     },
+    "ManagerOf": {
+        "@id": "pot:ManagerOf",
+        "@type": "pot:Class",
+        "subClassOf": "dli:Role",
+        "rdfs:label": {
+            "en-us": "Manager of"
+        }
+    },
+    "Building": {
+        "@id": "pot:Building",
+        "@type": "pot:Class",
+        "subClassOf": "dli:BuiltEnvironment",
+        "rdfs:label": {
+            "en-us": "Building"
+        }
+    },
     "OwnerAt": {
         "@id": "pot:OwnerAt",
         "@type": "pot:Class",
         "subClassOf": "dli:Role",
         "rdfs:label": {
             "en-us": "Owner at"
+        }
+    },
+    "Case": {
+        "@id": "pot:Case",
+        "@type": "pot:Class",
+        "subClassOf": "dli:Virtual",
+        "rdfs:label": {
+            "en-us": "Case"
+        }
+    },
+    "Class": {
+        "@id": "pot:Class",
+        "@type": "pot:Class",
+        "subClassOf": "rdfs:Class",
+        "rdfs:label": {
+            "en-us": "PoT Class"
+        }
+    },
+    "Storey": {
+        "@id": "pot:Storey",
+        "@type": "pot:Class",
+        "subClassOf": "dli:BuiltEnvironment",
+        "rdfs:label": {
+            "en-us": "Storey"
+        }
+    },
+    "Room": {
+        "@id": "pot:Room",
+        "@type": "pot:Class",
+        "subClassOf": "dli:BuiltEnvironment",
+        "rdfs:label": {
+            "en-us": "Room"
+        }
+    },
+    "Organization": {
+        "@id": "pot:Organization",
+        "@type": "pot:Class",
+        "subClassOf": "dli:Group",
+        "rdfs:label": {
+            "en-us": "Organization"
+        }
+    },
+    "Device": {
+        "@id": "pot:Device",
+        "@type": "pot:Class",
+        "subClassOf": "dli:Thing",
+        "rdfs:label": {
+            "en-us": "Device"
+        }
+    },
+    "BelongsTo": {
+        "@id": "pot:BelongsTo",
+        "@type": "pot:Class",
+        "subClassOf": "dli:Role",
+        "rdfs:label": {
+            "en-us": "Belongs to"
+        }
+    },
+    "TenantAt": {
+        "@id": "pot:TenantAt",
+        "@type": "pot:Class",
+        "subClassOf": "dli:Role",
+        "rdfs:label": {
+            "en-us": "Tenant at"
+        }
+    },
+    "OwnerOf": {
+        "@id": "pot:OwnerOf",
+        "@type": "pot:Class",
+        "subClassOf": "dli:Role",
+        "rdfs:label": {
+            "en-us": "Owner of"
+        }
+    },
+    "BuildingSystems": {
+        "@id": "pot:BuildingSystems",
+        "@type": "pot:Class",
+        "subClassOf": "dli:System",
+        "rdfs:label": {
+            "en-us": "Building Systems"
+        }
+    },
+    "BuildingElement": {
+        "@id": "pot:BuildingElement",
+        "@type": "pot:Class",
+        "subClassOf": "dli:Thing",
+        "rdfs:label": {
+            "en-us": "Building Element"
+        }
+    },
+    "LocatedAt": {
+        "@id": "pot:LocatedAt",
+        "@type": "pot:Class",
+        "subClassOf": "dli:Role",
+        "rdfs:label": {
+            "en-us": "Located at"
         }
     },
     "SupportedClass": {

--- a/v1/Vocabulary/Building.jsonld
+++ b/v1/Vocabulary/Building.jsonld
@@ -61,22 +61,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "fi-fi": "Rakennuksen kuvaus",
-            "en-us": "Building description"
+            "en-us": "Building description",
+            "fi-fi": "Rakennuksen kuvaus"
         },
         "rdfs:comment": {
             "en-us": "Description of the building"
         },
         "domain": [
-            "pot:Device",
+            "pot:Space",
+            "pot:Storey",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
             "pot:Room",
+            "pot:Case",
             "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
         ],
         "range": [
             "xsd:string"
@@ -84,16 +84,127 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "cultureHistorySignificance": {
-        "@id": "pot:categorization/cultureHistorySignificance",
+    "idOfficialTemporary": {
+        "@id": "pot:identifier/idOfficialTemporary",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Kulttuurihistoriallisesti merkittävä",
-            "en-us": "Cultural or historical significance"
+            "en-us": "Temporary official Id",
+            "fi-fi": "Väliaikainen rakennustunnus"
         },
         "rdfs:comment": {
-            "en-us": "Categorization if building is culturally significant"
+            "en-us": "Temporary identifier given officially to the building in Finland"
+        },
+        "domain": [
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the building"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "inspectionMomentYear": {
+        "@id": "pot:lifeCycle/inspectionMomentYear",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "fi-fi": "Loppukatselmus",
+            "en-us": "Inspection year"
+        },
+        "rdfs:comment": {
+            "en-us": "Inspection year of the building"
+        },
+        "domain": [
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:gYear"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "completionMomentYear": {
+        "@id": "pot:lifeCycle/completionMomentYear",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "fi-fi": "Valmistumisvuosi ",
+            "en-us": "Completion year"
+        },
+        "rdfs:comment": {
+            "en-us": "Completion year of the building"
+        },
+        "domain": [
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:gYear"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Building",
+            "pot:RealEstate",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "idOfficialPermanent": {
+        "@id": "pot:identifier/idOfficialPermanent",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Permanent official Id",
+            "fi-fi": "Pysyvä rakennustunnus "
+        },
+        "rdfs:comment": {
+            "en-us": "Permanent identifier given officially to the building in Finland"
         },
         "domain": [
             "pot:Building"
@@ -116,13 +227,13 @@
             "en-us": "Name of the building"
         },
         "domain": [
-            "pot:Device",
             "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
+            "pot:BuildingElement",
             "pot:RealEstate",
-            "pot:BuildingElement"
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -162,144 +273,12 @@
             "en-us": "Volume of the building"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
             "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "completionMomentYear": {
-        "@id": "pot:lifeCycle/completionMomentYear",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Completion year",
-            "fi-fi": "Valmistumisvuosi "
-        },
-        "rdfs:comment": {
-            "en-us": "Completion year of the building"
-        },
-        "domain": [
-            "pot:Building"
-        ],
-        "range": [
-            "xsd:gYear"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "idOfficialPermanent": {
-        "@id": "pot:identifier/idOfficialPermanent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "Pysyvä rakennustunnus ",
-            "en-us": "Permanent official Id"
-        },
-        "rdfs:comment": {
-            "en-us": "Permanent identifier given officially to the building in Finland"
-        },
-        "domain": [
-            "pot:Building"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "inspectionMomentYear": {
-        "@id": "pot:lifeCycle/inspectionMomentYear",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Inspection year",
-            "fi-fi": "Loppukatselmus"
-        },
-        "rdfs:comment": {
-            "en-us": "Inspection year of the building"
-        },
-        "domain": [
-            "pot:Building"
-        ],
-        "range": [
-            "xsd:gYear"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status of the building"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
-        },
-        "rdfs:comment": {
-            "en-us": "Height of the building"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "areaSquareMeterLivingNet": {
-        "@id": "pot:physical/areaSquareMeterLivingNet",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Asuin pinta-ala - netto",
-            "en-us": "Living space net square meters"
-        },
-        "rdfs:comment": {
-            "en-us": "Living space net square meters"
-        },
-        "domain": [
-            "pot:Building"
         ],
         "range": [
             "xsd:decimal"
@@ -327,16 +306,16 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idOfficialTemporary": {
-        "@id": "pot:identifier/idOfficialTemporary",
+    "cultureHistorySignificance": {
+        "@id": "pot:categorization/cultureHistorySignificance",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Temporary official Id",
-            "fi-fi": "Väliaikainen rakennustunnus"
+            "fi-fi": "Kulttuurihistoriallisesti merkittävä",
+            "en-us": "Cultural or historical significance"
         },
         "rdfs:comment": {
-            "en-us": "Temporary identifier given officially to the building in Finland"
+            "en-us": "Categorization if building is culturally significant"
         },
         "domain": [
             "pot:Building"
@@ -347,26 +326,47 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
+    "areaSquareMeterLivingNet": {
+        "@id": "pot:physical/areaSquareMeterLivingNet",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC GUID",
-            "fi-fi": "IFC GUID"
+            "fi-fi": "Asuin pinta-ala - netto",
+            "en-us": "Living space net square meters"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
+            "en-us": "Living space net square meters"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status of the building"
+        },
+        "domain": [
             "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
             "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
+            "pot:Device",
+            "pot:Case",
             "pot:Building",
-            "pot:Space"
+            "pot:Room"
         ],
         "range": [
             "xsd:string"

--- a/v1/Vocabulary/BuildingElement.jsonld
+++ b/v1/Vocabulary/BuildingElement.jsonld
@@ -56,66 +56,19 @@
             "en-us": "The building element comprises all elements that are primarily part of the construction of a building, i.e., its structural and space separating system."
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -489,17 +468,33 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "Roof": {
-        "rdfs:subClassOf": {
-            "@id": "pot:BuildingElement"
-        }
-    },
-    "Stair": {
-        "rdfs:subClassOf": {
-            "@id": "pot:BuildingElement"
-        }
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
     },
     "Door": {
+        "rdfs:subClassOf": {
+            "@id": "pot:BuildingElement"
+        }
+    },
+    "CurtainWall": {
         "rdfs:subClassOf": {
             "@id": "pot:BuildingElement"
         }
@@ -509,7 +504,7 @@
             "@id": "pot:BuildingElement"
         }
     },
-    "CurtainWall": {
+    "Roof": {
         "rdfs:subClassOf": {
             "@id": "pot:BuildingElement"
         }
@@ -524,7 +519,7 @@
             "@id": "pot:BuildingElement"
         }
     },
-    "Beam": {
+    "Window": {
         "rdfs:subClassOf": {
             "@id": "pot:BuildingElement"
         }
@@ -534,7 +529,12 @@
             "@id": "pot:BuildingElement"
         }
     },
-    "Window": {
+    "Beam": {
+        "rdfs:subClassOf": {
+            "@id": "pot:BuildingElement"
+        }
+    },
+    "Stair": {
         "rdfs:subClassOf": {
             "@id": "pot:BuildingElement"
         }

--- a/v1/Vocabulary/BuildingElement/Beam.jsonld
+++ b/v1/Vocabulary/BuildingElement/Beam.jsonld
@@ -56,66 +56,19 @@
             "en-us": "Sturdy piece of timber or metal used to support the roof or floor of a building"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingElement/Column.jsonld
+++ b/v1/Vocabulary/BuildingElement/Column.jsonld
@@ -56,66 +56,19 @@
             "en-us": "An upright pillar (typically cylindrical) supporting an arch, entablature, or other structure"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingElement/CurtainWall.jsonld
+++ b/v1/Vocabulary/BuildingElement/CurtainWall.jsonld
@@ -56,66 +56,19 @@
             "en-us": "A curtain wall system is an outer covering of a building in which the outer elements are non-structural"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingElement/Door.jsonld
+++ b/v1/Vocabulary/BuildingElement/Door.jsonld
@@ -56,66 +56,19 @@
             "en-us": "A hinged, sliding, or revolving barrier at the entrance to a building, room, or vehicle (any space type)"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingElement/Floor.jsonld
+++ b/v1/Vocabulary/BuildingElement/Floor.jsonld
@@ -53,69 +53,22 @@
             "en-us": "Floor"
         },
         "rdfs:comment": {
-            "en-us": "Floor is composed of the structural objects which are built on top of story"
+            "en-us": "Floor is composed of the structural objects which are built on top of storey"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingElement/Roof.jsonld
+++ b/v1/Vocabulary/BuildingElement/Roof.jsonld
@@ -56,66 +56,19 @@
             "en-us": "The structure forming the upper covering of a building or vehicle"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingElement/Slab.jsonld
+++ b/v1/Vocabulary/BuildingElement/Slab.jsonld
@@ -56,66 +56,19 @@
             "en-us": "Flat piece of stone or concrete used in built structures "
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingElement/Stair.jsonld
+++ b/v1/Vocabulary/BuildingElement/Stair.jsonld
@@ -53,69 +53,22 @@
             "en-us": "Stair"
         },
         "rdfs:comment": {
-            "en-us": "A set of steps leading from one story of a building to another"
+            "en-us": "A set of steps leading from one storey of a building to another"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingElement/Wall.jsonld
+++ b/v1/Vocabulary/BuildingElement/Wall.jsonld
@@ -56,66 +56,19 @@
             "en-us": "A continuous vertical structure that encloses or divides an area/space"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingElement/Window.jsonld
+++ b/v1/Vocabulary/BuildingElement/Window.jsonld
@@ -56,66 +56,19 @@
             "en-us": "An opening in the wall or roof of a building or vehicle, fitted with glass in a frame to admit light or air and allow people to see out."
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Height",
-            "fi-fi": "Korkeus"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Height of the element"
+            "en-us": "Width of the element"
         },
         "domain": [
             "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
             "pot:BuildingElement"
         ],
         "range": [
@@ -129,108 +82,24 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
         },
         "rdfs:comment": {
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color",
-            "fi-fi": "Väri"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Length",
-            "fi-fi": "Pituus"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Color code",
-            "fi-fi": "Väritunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -240,8 +109,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - netto",
-            "en-us": "Area - net"
+            "en-us": "Area - net",
+            "fi-fi": "Pinta-ala - netto"
         },
         "rdfs:comment": {
             "en-us": "Net area of the element"
@@ -256,149 +125,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Building element description",
-            "fi-fi": "Rakennuselementin kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the building element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
+    "idInstance": {
+        "@id": "pot:identifier/idInstance",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "fi-fi": "Yksilöllinen tunnus",
+            "en-us": "Unique identifier"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the building element"
+            "en-us": "Unique identifier for the element instance"
         },
         "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
             "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the element"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcElementName": {
-        "@id": "pot:categorization/ifcElementName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "IFC element name",
-            "fi-fi": "IFC elementti nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard element name"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the element"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "en-us": "Life cycle status",
-            "fi-fi": "Elinkaari - Status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -427,18 +166,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idInstance": {
-        "@id": "pot:identifier/idInstance",
+    "length": {
+        "@id": "pot:physical/length",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Length",
+            "fi-fi": "Pituus"
+        },
+        "rdfs:comment": {
+            "en-us": "Length of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Yksilöllinen tunnus",
-            "en-us": "Unique identifier"
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the element instance"
+            "en-us": "Code given locally for the building element"
         },
         "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the element"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -447,20 +229,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Type name given locally",
+            "fi-fi": "Lokaali tyypitys"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Categorisation name given locally"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementName": {
+        "@id": "pot:categorization/ifcElementName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti nimi",
+            "en-us": "IFC element name"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element name"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the element"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Rakennuselementin kuvaus",
+            "en-us": "Building element description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the building element"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the element"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Color code of the element"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the element"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the building element"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -485,6 +464,27 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/BuildingSystems.jsonld
+++ b/v1/Vocabulary/BuildingSystems.jsonld
@@ -56,7 +56,7 @@
             "en-us": "Buiding systems are composed of multiple objects, ususally devices that are used to control and maintain desired conditions within building context"
         }
     },
-    "BuildingAutomationSystem": {
+    "SewageSystem": {
         "rdfs:subClassOf": {
             "@id": "pot:BuildingSystems"
         }
@@ -66,27 +66,12 @@
             "@id": "pot:BuildingSystems"
         }
     },
-    "VideoSurveillanceSystem": {
-        "rdfs:subClassOf": {
-            "@id": "pot:BuildingSystems"
-        }
-    },
-    "LightingSystem": {
-        "rdfs:subClassOf": {
-            "@id": "pot:BuildingSystems"
-        }
-    },
-    "AirConditioningSystem": {
-        "rdfs:subClassOf": {
-            "@id": "pot:BuildingSystems"
-        }
-    },
     "VentilationSystem": {
         "rdfs:subClassOf": {
             "@id": "pot:BuildingSystems"
         }
     },
-    "SewageSystem": {
+    "VideoSurveillanceSystem": {
         "rdfs:subClassOf": {
             "@id": "pot:BuildingSystems"
         }
@@ -96,7 +81,22 @@
             "@id": "pot:BuildingSystems"
         }
     },
+    "LightingSystem": {
+        "rdfs:subClassOf": {
+            "@id": "pot:BuildingSystems"
+        }
+    },
     "HeatingSystem": {
+        "rdfs:subClassOf": {
+            "@id": "pot:BuildingSystems"
+        }
+    },
+    "AirConditioningSystem": {
+        "rdfs:subClassOf": {
+            "@id": "pot:BuildingSystems"
+        }
+    },
+    "BuildingAutomationSystem": {
         "rdfs:subClassOf": {
             "@id": "pot:BuildingSystems"
         }

--- a/v1/Vocabulary/Case.jsonld
+++ b/v1/Vocabulary/Case.jsonld
@@ -61,22 +61,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "fi-fi": "Palvelupyynnön kuvaus",
-            "en-us": "Case description"
+            "en-us": "Case description",
+            "fi-fi": "Palvelupyynnön kuvaus"
         },
         "rdfs:comment": {
             "en-us": "Description of the case"
         },
         "domain": [
-            "pot:Device",
+            "pot:Space",
+            "pot:Storey",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
             "pot:Room",
+            "pot:Case",
             "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
         ],
         "range": [
             "xsd:string"
@@ -84,45 +84,22 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idlocal": {
-        "@id": "pot:identifier/idlocal",
+    "nameLocal": {
+        "@id": "pot:identifier/nameLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "en-us": "Case Id",
-            "fi-fi": "Palvelupyynnön tunniste"
+            "fi-fi": "Palvelupyynnön otsikko",
+            "en-us": "Case header"
         },
         "rdfs:comment": {
-            "en-us": "Local identifier (system identifier) "
+            "en-us": "Locally given name (source system name) "
         },
         "domain": [
-            "pot:Story",
-            "pot:Space",
-            "pot:Room",
             "pot:Case"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "endDateTime": {
-        "@id": "pot:time/endDateTime",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:time",
-        "rdfs:label": {
-            "fi-fi": "Lopetusaika",
-            "en-us": "End time"
-        },
-        "rdfs:comment": {
-            "en-us": "End time of the case"
-        },
-        "domain": [
-            "pot:Case"
-        ],
-        "range": [
-            "xsd:dateTime"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -147,30 +124,45 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "status": {
-        "@id": "pot:lifeCycle/status",
+    "idLocal": {
+        "@id": "pot:identifier/idLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
+        "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "en-us": "Case status",
-            "fi-fi": "Palvelupyynnön tila"
+            "en-us": "Case Id",
+            "fi-fi": "Palvelupyynnön tunniste"
         },
         "rdfs:comment": {
-            "en-us": "Case state"
+            "en-us": "Local identifier (system identifier) "
         },
         "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
             "pot:Case",
+            "pot:Room",
             "pot:Space",
-            "pot:Device"
+            "pot:Storey"
         ],
         "range": [
             "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "endDateTime": {
+        "@id": "pot:time/endDateTime",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:time",
+        "rdfs:label": {
+            "en-us": "End time",
+            "fi-fi": "Lopetusaika"
+        },
+        "rdfs:comment": {
+            "en-us": "End time of the case"
+        },
+        "domain": [
+            "pot:Case"
+        ],
+        "range": [
+            "xsd:dateTime"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -195,19 +187,27 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "duration": {
-        "@id": "pot:time/duration",
+    "status": {
+        "@id": "pot:lifeCycle/status",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:time",
+        "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Kesto",
-            "en-us": "Duration"
+            "en-us": "Case status",
+            "fi-fi": "Palvelupyynnön tila"
         },
         "rdfs:comment": {
-            "en-us": "Duration of the case"
+            "en-us": "Case state"
         },
         "domain": [
-            "pot:Case"
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -215,16 +215,16 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "nameLocal": {
-        "@id": "pot:identifier/nameLocal",
+    "duration": {
+        "@id": "pot:time/duration",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:time",
         "rdfs:label": {
-            "en-us": "Case header",
-            "fi-fi": "Palvelupyynnön otsikko"
+            "en-us": "Duration",
+            "fi-fi": "Kesto"
         },
         "rdfs:comment": {
-            "en-us": "Locally given name (source system name) "
+            "en-us": "Duration of the case"
         },
         "domain": [
             "pot:Case"

--- a/v1/Vocabulary/Device.jsonld
+++ b/v1/Vocabulary/Device.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Device is object (product) that is capable of performing processes and can be controlled thus typically configured.  "
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -549,12 +508,58 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
     "WaterDevice": {
         "rdfs:subClassOf": {
             "@id": "pot:Device"
         }
     },
     "SecurityDevice": {
+        "rdfs:subClassOf": {
+            "@id": "pot:Device"
+        }
+    },
+    "VentilationDevice": {
         "rdfs:subClassOf": {
             "@id": "pot:Device"
         }
@@ -569,22 +574,22 @@
             "@id": "pot:Device"
         }
     },
+    "QrCode": {
+        "rdfs:subClassOf": {
+            "@id": "pot:Device"
+        }
+    },
     "AirFilteringDevice": {
         "rdfs:subClassOf": {
             "@id": "pot:Device"
         }
     },
-    "Sensor": {
-        "rdfs:subClassOf": {
-            "@id": "pot:Device"
-        }
-    },
-    "VentilationDevice": {
-        "rdfs:subClassOf": {
-            "@id": "pot:Device"
-        }
-    },
     "PowerDevice": {
+        "rdfs:subClassOf": {
+            "@id": "pot:Device"
+        }
+    },
+    "Sensor": {
         "rdfs:subClassOf": {
             "@id": "pot:Device"
         }

--- a/v1/Vocabulary/Device/AirConditioningDevice.jsonld
+++ b/v1/Vocabulary/Device/AirConditioningDevice.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Device used for air conditioning"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/AirFilteringDevice.jsonld
+++ b/v1/Vocabulary/Device/AirFilteringDevice.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Devices which control or provide air flow within building (or other structure)"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/HeatingDevice.jsonld
+++ b/v1/Vocabulary/Device/HeatingDevice.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Device used for air heating"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/HeatingDevice/Radiator.jsonld
+++ b/v1/Vocabulary/Device/HeatingDevice/Radiator.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Device used for transferring heat"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/PowerDevice.jsonld
+++ b/v1/Vocabulary/Device/PowerDevice.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Devices which control or provide electricity within building (or other structure)"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/QrCode.jsonld
+++ b/v1/Vocabulary/Device/QrCode.jsonld
@@ -43,17 +43,17 @@
             ]
         }
     },
-    "Faucet": {
-        "@id": "pot:Faucet",
+    "QrCode": {
+        "@id": "pot:QrCode",
         "@type": "pot:Class",
-        "subClassOf": "pot:WaterDevice",
+        "subClassOf": "pot:Device",
         "vs:term_status": "unstable",
         "owl:versionInfo": "DRAFT",
         "rdfs:label": {
-            "en-us": "Faucet"
+            "en-us": "QR Code"
         },
         "rdfs:comment": {
-            "en-us": "Device which controls the flow of liquid"
+            "en-us": "A machine-readable code consisting of an array of black and white squares, typically used for storing URLs or other information for reading by the camera on a smartphone"
         }
     },
     "electricityCurrent": {

--- a/v1/Vocabulary/Device/SecurityDevice.jsonld
+++ b/v1/Vocabulary/Device/SecurityDevice.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Device used for security"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/Sensor.jsonld
+++ b/v1/Vocabulary/Device/Sensor.jsonld
@@ -56,67 +56,19 @@
             "en-us": "A sensor is a device, module, or subsystem whose purpose is to detect events or changes in its environment and send the information to other electronics, frequently a computer processor. A sensor is always used with other electronics"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -549,7 +508,53 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
     "CarbonDioxideSensor": {
+        "rdfs:subClassOf": {
+            "@id": "pot:Device/Sensor"
+        }
+    },
+    "TemperatureSensor": {
         "rdfs:subClassOf": {
             "@id": "pot:Device/Sensor"
         }
@@ -559,12 +564,12 @@
             "@id": "pot:Device/Sensor"
         }
     },
-    "QuantitySensor": {
+    "HumiditySensor": {
         "rdfs:subClassOf": {
             "@id": "pot:Device/Sensor"
         }
     },
-    "TemperatureSensor": {
+    "QuantitySensor": {
         "rdfs:subClassOf": {
             "@id": "pot:Device/Sensor"
         }

--- a/v1/Vocabulary/Device/Sensor/CarbonDioxideSensor.jsonld
+++ b/v1/Vocabulary/Device/Sensor/CarbonDioxideSensor.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Sensor which measures carbon dioxide"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/Sensor/HumiditySensor.jsonld
+++ b/v1/Vocabulary/Device/Sensor/HumiditySensor.jsonld
@@ -43,17 +43,17 @@
             ]
         }
     },
-    "Faucet": {
-        "@id": "pot:Faucet",
+    "HumiditySensor": {
+        "@id": "pot:HumiditySensor",
         "@type": "pot:Class",
-        "subClassOf": "pot:WaterDevice",
+        "subClassOf": "pot:Sensor",
         "vs:term_status": "unstable",
         "owl:versionInfo": "DRAFT",
         "rdfs:label": {
-            "en-us": "Faucet"
+            "en-us": "Humidity Sensor"
         },
         "rdfs:comment": {
-            "en-us": "Device which controls the flow of liquid"
+            "en-us": "A sensor which measures humidity"
         }
     },
     "electricityCurrent": {

--- a/v1/Vocabulary/Device/Sensor/PresenceSensor.jsonld
+++ b/v1/Vocabulary/Device/Sensor/PresenceSensor.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Sensor which measures if there some objects are present in spesific place"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/Sensor/QuantitySensor.jsonld
+++ b/v1/Vocabulary/Device/Sensor/QuantitySensor.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Sensor which measures quantity of something"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/Sensor/TemperatureSensor.jsonld
+++ b/v1/Vocabulary/Device/Sensor/TemperatureSensor.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Sensor which measures temperature"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/VentilationDevice.jsonld
+++ b/v1/Vocabulary/Device/VentilationDevice.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Device used for air ventilation"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Device/WaterDevice.jsonld
+++ b/v1/Vocabulary/Device/WaterDevice.jsonld
@@ -56,67 +56,19 @@
             "en-us": "Devices which control or provide water within building (or other structure)"
         }
     },
-    "codeLocal": {
-        "@id": "pot:identifier/codeLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local code",
-            "fi-fi": "Paikallinen koodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Code given locally for the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Type name given locally",
-            "fi-fi": "Lokaali tyypitys"
-        },
-        "rdfs:comment": {
-            "en-us": "Categorisation name given locally"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
+    "electricityCurrent": {
+        "@id": "pot:physical/electricityCurrent",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
+            "fi-fi": "Sähkövirta",
+            "en-us": "Electric current"
         },
         "rdfs:comment": {
-            "en-us": "Height of the device"
+            "en-us": "An electric current is the rate of flow of electric charge past a point"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:decimal"
@@ -124,22 +76,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "serialNumber": {
-        "@id": "pot:identifier/serialNumber",
+    "width": {
+        "@id": "pot:physical/width",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Sarjanumero",
-            "en-us": "Serial number"
+            "en-us": "Width",
+            "fi-fi": "Leveys"
         },
         "rdfs:comment": {
-            "en-us": "Unique identifier for the device instance"
+            "en-us": "Width of the device"
         },
         "domain": [
-            "pot:Device"
+            "pot:Device",
+            "pot:BuildingElement"
         ],
         "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -156,161 +109,17 @@
             "en-us": "IFC standard based Globally Unique Identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
+            "pot:Space",
+            "pot:Storey",
             "pot:Organization",
-            "pot:RealEstate",
+            "pot:BuildingElement",
             "pot:Room",
-            "pot:Story",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorName": {
-        "@id": "pot:physical/colorName",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väri",
-            "en-us": "Color"
-        },
-        "rdfs:comment": {
-            "en-us": "Color of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device"
         ],
         "range": [
             "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "electricityCurrent": {
-        "@id": "pot:physical/electricityCurrent",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Electric current",
-            "fi-fi": "Sähkövirta"
-        },
-        "rdfs:comment": {
-            "en-us": "An electric current is the rate of flow of electric charge past a point"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "power": {
-        "@id": "pot:physical/power",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Teho (W)",
-            "en-us": "Power (W)"
-        },
-        "rdfs:comment": {
-            "en-us": "Power measured in Watts"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "industryDomain": {
-        "@id": "pot:categorization/industryDomain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tekniikan ala",
-            "en-us": "Industry sector name"
-        },
-        "rdfs:comment": {
-            "en-us": "Industry sector name to which the device belongs"
-        },
-        "domain": [
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "length": {
-        "@id": "pot:physical/length",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pituus",
-            "en-us": "Length"
-        },
-        "rdfs:comment": {
-            "en-us": "Length of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "colorCode": {
-        "@id": "pot:physical/colorCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Väritunnus",
-            "en-us": "Color code"
-        },
-        "rdfs:comment": {
-            "en-us": "Color code of the device"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "width": {
-        "@id": "pot:physical/width",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Leveys",
-            "en-us": "Width"
-        },
-        "rdfs:comment": {
-            "en-us": "Width of the device"
-        },
-        "domain": [
-            "pot:BuildingElement",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -336,27 +145,40 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "areaGross": {
+        "@id": "pot:physical/areaGross",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Device description",
-            "fi-fi": "Laitteen kuvaus"
+            "fi-fi": "Pinta-ala - brutto",
+            "en-us": "Area - gross"
         },
         "rdfs:comment": {
-            "en-us": "Description of the device"
+            "en-us": "Gross area of the device"
         },
         "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "industryDomain": {
+        "@id": "pot:categorization/industryDomain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "en-us": "Industry sector name",
+            "fi-fi": "Tekniikan ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Industry sector name to which the device belongs"
+        },
+        "domain": [
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -364,24 +186,61 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "name": {
-        "@id": "pot:identifier/name",
+    "length": {
+        "@id": "pot:physical/length",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Paikallinen nimi",
-            "en-us": "Local name"
+            "en-us": "Length",
+            "fi-fi": "Pituus"
         },
         "rdfs:comment": {
-            "en-us": "Name given locally for the device"
+            "en-us": "Length of the device"
         },
         "domain": [
             "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "codeLocal": {
+        "@id": "pot:identifier/codeLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen koodi",
+            "en-us": "Local code"
+        },
+        "rdfs:comment": {
+            "en-us": "Code given locally for the device"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "colorName": {
+        "@id": "pot:physical/colorName",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Väri",
+            "en-us": "Color"
+        },
+        "rdfs:comment": {
+            "en-us": "Color of the device"
+        },
+        "domain": [
+            "pot:Device",
             "pot:BuildingElement"
         ],
         "range": [
@@ -390,27 +249,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
+            "fi-fi": "Lokaali tyypitys",
+            "en-us": "Type name given locally"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the device"
+            "en-us": "Categorisation name given locally"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Device"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -436,21 +293,76 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "thickness": {
-        "@id": "pot:physical/thickness",
+    "volume": {
+        "@id": "pot:physical/volume",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
         },
         "rdfs:comment": {
-            "en-us": "Thickness of the device"
+            "en-us": "Volume of the device"
         },
         "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
             "pot:Device",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "fi-fi": "Laitteen kuvaus",
+            "en-us": "Device description"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the device"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the device"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -463,22 +375,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -486,19 +398,18 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaGross": {
-        "@id": "pot:physical/areaGross",
+    "power": {
+        "@id": "pot:physical/power",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala - brutto",
-            "en-us": "Area - gross"
+            "fi-fi": "Teho (W)",
+            "en-us": "Power (W)"
         },
         "rdfs:comment": {
-            "en-us": "Gross area of the device"
+            "en-us": "Power measured in Watts"
         },
         "domain": [
-            "pot:BuildingElement",
             "pot:Device"
         ],
         "range": [
@@ -507,20 +418,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcElementType": {
-        "@id": "pot:categorization/ifcElementType",
+    "colorCode": {
+        "@id": "pot:physical/colorCode",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
+        "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "IFC element type",
-            "fi-fi": "IFC elementti tyyppi"
+            "en-us": "Color code",
+            "fi-fi": "Väritunnus"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard element type"
+            "en-us": "Color code of the device"
         },
         "domain": [
             "pot:BuildingElement",
             "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the device"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Local name",
+            "fi-fi": "Paikallinen nimi"
+        },
+        "rdfs:comment": {
+            "en-us": "Name given locally for the device"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -545,6 +504,47 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcElementType": {
+        "@id": "pot:categorization/ifcElementType",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "IFC elementti tyyppi",
+            "en-us": "IFC element type"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard element type"
+        },
+        "domain": [
+            "pot:BuildingElement",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "serialNumber": {
+        "@id": "pot:identifier/serialNumber",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Serial number",
+            "fi-fi": "Sarjanumero"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier for the device instance"
+        },
+        "domain": [
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Organization.jsonld
+++ b/v1/Vocabulary/Organization.jsonld
@@ -68,15 +68,42 @@
             "en-us": "Description of the organization"
         },
         "domain": [
-            "pot:Device",
+            "pot:Space",
+            "pot:Storey",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
             "pot:Room",
+            "pot:Case",
             "pot:RealEstate",
-            "pot:Story",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
             "pot:Building",
-            "pot:Space"
+            "pot:RealEstate",
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -96,13 +123,13 @@
             "en-us": "Name of the organization"
         },
         "domain": [
-            "pot:Device",
             "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
+            "pot:BuildingElement",
             "pot:RealEstate",
-            "pot:BuildingElement"
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -115,8 +142,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Industry category",
-            "fi-fi": "Toimialaluokka"
+            "fi-fi": "Toimialaluokka",
+            "en-us": "Industry category"
         },
         "rdfs:comment": {
             "en-us": "Organization categorization given by official authority"
@@ -152,26 +179,6 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "taxVatCode": {
-        "@id": "pot:identifier/taxVatCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "VAT code",
-            "fi-fi": "ALV-tunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Value-added taxation identifier"
-        },
-        "domain": [
-            "pot:Organization"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
     "status": {
         "@id": "pot:lifeCycle/status",
         "@type": "rdf:Property",
@@ -185,14 +192,14 @@
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -200,26 +207,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
+    "taxVatCode": {
+        "@id": "pot:identifier/taxVatCode",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "en-us": "IFC GUID",
-            "fi-fi": "IFC GUID"
+            "fi-fi": "ALV-tunnus",
+            "en-us": "VAT code"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
+            "en-us": "Value-added taxation identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Organization"
         ],
         "range": [
             "xsd:string"

--- a/v1/Vocabulary/Organization/LimitedCompany.jsonld
+++ b/v1/Vocabulary/Organization/LimitedCompany.jsonld
@@ -68,15 +68,42 @@
             "en-us": "Description of the organization"
         },
         "domain": [
-            "pot:Device",
+            "pot:Space",
+            "pot:Storey",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
             "pot:Room",
+            "pot:Case",
             "pot:RealEstate",
-            "pot:Story",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
             "pot:Building",
-            "pot:Space"
+            "pot:RealEstate",
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -96,13 +123,13 @@
             "en-us": "Name of the organization"
         },
         "domain": [
-            "pot:Device",
             "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
+            "pot:BuildingElement",
             "pot:RealEstate",
-            "pot:BuildingElement"
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -115,8 +142,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Industry category",
-            "fi-fi": "Toimialaluokka"
+            "fi-fi": "Toimialaluokka",
+            "en-us": "Industry category"
         },
         "rdfs:comment": {
             "en-us": "Organization categorization given by official authority"
@@ -152,26 +179,6 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "taxVatCode": {
-        "@id": "pot:identifier/taxVatCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "VAT code",
-            "fi-fi": "ALV-tunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Value-added taxation identifier"
-        },
-        "domain": [
-            "pot:Organization"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
     "status": {
         "@id": "pot:lifeCycle/status",
         "@type": "rdf:Property",
@@ -185,14 +192,14 @@
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -200,26 +207,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
+    "taxVatCode": {
+        "@id": "pot:identifier/taxVatCode",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "en-us": "IFC GUID",
-            "fi-fi": "IFC GUID"
+            "fi-fi": "ALV-tunnus",
+            "en-us": "VAT code"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
+            "en-us": "Value-added taxation identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Organization"
         ],
         "range": [
             "xsd:string"

--- a/v1/Vocabulary/Organization/LimitedCompany/HousingCooperative.jsonld
+++ b/v1/Vocabulary/Organization/LimitedCompany/HousingCooperative.jsonld
@@ -68,15 +68,42 @@
             "en-us": "Description of the organization"
         },
         "domain": [
-            "pot:Device",
+            "pot:Space",
+            "pot:Storey",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
             "pot:Room",
+            "pot:Case",
             "pot:RealEstate",
-            "pot:Story",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
             "pot:Building",
-            "pot:Space"
+            "pot:RealEstate",
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -96,13 +123,13 @@
             "en-us": "Name of the organization"
         },
         "domain": [
-            "pot:Device",
             "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
+            "pot:BuildingElement",
             "pot:RealEstate",
-            "pot:BuildingElement"
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -115,8 +142,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Industry category",
-            "fi-fi": "Toimialaluokka"
+            "fi-fi": "Toimialaluokka",
+            "en-us": "Industry category"
         },
         "rdfs:comment": {
             "en-us": "Organization categorization given by official authority"
@@ -152,26 +179,6 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "taxVatCode": {
-        "@id": "pot:identifier/taxVatCode",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "VAT code",
-            "fi-fi": "ALV-tunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Value-added taxation identifier"
-        },
-        "domain": [
-            "pot:Organization"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
     "status": {
         "@id": "pot:lifeCycle/status",
         "@type": "rdf:Property",
@@ -185,14 +192,14 @@
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -200,26 +207,19 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
+    "taxVatCode": {
+        "@id": "pot:identifier/taxVatCode",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "en-us": "IFC GUID",
-            "fi-fi": "IFC GUID"
+            "fi-fi": "ALV-tunnus",
+            "en-us": "VAT code"
         },
         "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
+            "en-us": "Value-added taxation identifier"
         },
         "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Organization"
         ],
         "range": [
             "xsd:string"

--- a/v1/Vocabulary/Room.jsonld
+++ b/v1/Vocabulary/Room.jsonld
@@ -56,6 +56,33 @@
             "en-us": "Room is any space enclosed within four walls to which entry is possible only by a door that connects it either to a passageway to another room, or to the outdoors, that is large enough for several persons to move about, and whose size, fixtures, furnishings, and sometimes placement within the building support the activity to be conducted in it."
         }
     },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Building",
+            "pot:RealEstate",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
     "categorizationOfficial": {
         "@id": "pot:categorization/categorizationOfficial",
         "@type": "rdf:Property",
@@ -78,6 +105,71 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
+    "idLocal": {
+        "@id": "pot:identifier/idLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen tunniste",
+            "en-us": "Local Id"
+        },
+        "rdfs:comment": {
+            "en-us": "Locally given identifier for the space"
+        },
+        "domain": [
+            "pot:Case",
+            "pot:Room",
+            "pot:Space",
+            "pot:Storey"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaLivingAudited": {
+        "@id": "pot:physical/sizeAreaLivingAudited",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Asuinpinta-ala - tarkistusmitattu",
+            "en-us": "Audited living area size"
+        },
+        "rdfs:comment": {
+            "en-us": "Size of audited area suitable for, or used for, living"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Room",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "temperature": {
+        "@id": "pot:physical/temperature",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Temperature",
+            "fi-fi": "Lämpötila"
+        },
+        "rdfs:comment": {
+            "en-us": "Temperature of the room"
+        },
+        "domain": [
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
     "categorizationLocal": {
         "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
@@ -90,13 +182,38 @@
             "en-us": "Space type name derived from local categorization naming"
         },
         "domain": [
-            "pot:Device",
             "pot:Room",
             "pot:Space",
-            "pot:BuildingElement"
+            "pot:BuildingElement",
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the object"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -106,8 +223,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Carbon dioxide",
-            "fi-fi": "Hiilidioksidi"
+            "fi-fi": "Hiilidioksidi",
+            "en-us": "Carbon dioxide"
         },
         "rdfs:comment": {
             "en-us": "Carbon dioxide level of the room"
@@ -117,6 +234,34 @@
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "en-us": "Room description",
+            "fi-fi": "Huoneen kuvaus"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the room"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -136,81 +281,11 @@
             "pot:Device",
             "pot:Building",
             "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "sizeAreaFloor": {
-        "@id": "pot:physical/sizeAreaFloor",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pinta-ala/Kerrosala",
-            "en-us": "Floor area size"
-        },
-        "rdfs:comment": {
-            "en-us": "Area of the space"
-        },
-        "domain": [
-            "pot:Room",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
-        },
-        "domain": [
-            "pot:Device",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Room"
         ],
         "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "usageMain": {
-        "@id": "pot:categorization/usageMain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Käyttötarkoitus",
-            "en-us": "Main usage purpose"
-        },
-        "rdfs:comment": {
-            "en-us": "Main usage purpose"
-        },
-        "domain": [
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -220,160 +295,16 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Huoneistoala/Asuinpinta-ala",
-            "en-us": "Living area size"
+            "en-us": "Living area size",
+            "fi-fi": "Huoneistoala/Asuinpinta-ala"
         },
         "rdfs:comment": {
             "en-us": "Size of area suitable for, or used for. living"
         },
         "domain": [
-            "pot:Story",
+            "pot:Storey",
             "pot:Space",
             "pot:Room"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "temperature": {
-        "@id": "pot:physical/temperature",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Lämpötila",
-            "en-us": "Temperature"
-        },
-        "rdfs:comment": {
-            "en-us": "Temperature of the room"
-        },
-        "domain": [
-            "pot:Room"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "idlocal": {
-        "@id": "pot:identifier/idlocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Local Id",
-            "fi-fi": "Paikallinen tunniste"
-        },
-        "rdfs:comment": {
-            "en-us": "Locally given identifier for the space"
-        },
-        "domain": [
-            "pot:Story",
-            "pot:Space",
-            "pot:Room",
-            "pot:Case"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "en-us": "Room description",
-            "fi-fi": "Huoneen kuvaus"
-        },
-        "rdfs:comment": {
-            "en-us": "Description of the room"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Room name",
-            "fi-fi": "Huoneen nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "Room name"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "volume": {
-        "@id": "pot:physical/volume",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Volume",
-            "fi-fi": "Tilavuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Volume of the object"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "sizeAreaLivingAudited": {
-        "@id": "pot:physical/sizeAreaLivingAudited",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Audited living area size",
-            "fi-fi": "Asuinpinta-ala - tarkistusmitattu"
-        },
-        "rdfs:comment": {
-            "en-us": "Size of audited area suitable for, or used for, living"
-        },
-        "domain": [
-            "pot:Space",
-            "pot:Room",
-            "pot:Story"
         ],
         "range": [
             "xsd:decimal"
@@ -401,21 +332,71 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "usageMain": {
+        "@id": "pot:categorization/usageMain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "Käyttötarkoitus",
+            "en-us": "Main usage purpose"
+        },
+        "rdfs:comment": {
+            "en-us": "Main usage purpose"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:RealEstate",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
     "idOfficial": {
         "@id": "pot:identifier/idOfficial",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Viranomaisen tunniste",
-            "en-us": "Official Id"
+            "en-us": "Official Id",
+            "fi-fi": "Viranomaisen tunniste"
         },
         "rdfs:comment": {
             "en-us": "Officially given identifier for the space"
         },
         "domain": [
-            "pot:Room",
             "pot:Space",
-            "pot:RealEstate"
+            "pot:RealEstate",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -443,27 +424,25 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "status": {
-        "@id": "pot:lifeCycle/status",
+    "name": {
+        "@id": "pot:identifier/name",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
+        "subPropertyOf": "pot:identifier",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "fi-fi": "Huoneen nimi",
+            "en-us": "Room name"
         },
         "rdfs:comment": {
-            "en-us": "Life cycle status"
+            "en-us": "Room name"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
+            "pot:BuildingElement",
             "pot:RealEstate",
             "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
@@ -483,12 +462,33 @@
             "en-us": "Additional information"
         },
         "domain": [
-            "pot:Space",
-            "pot:Story",
-            "pot:Room"
+            "pot:Room",
+            "pot:Storey",
+            "pot:Space"
         ],
         "range": [
             "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaFloor": {
+        "@id": "pot:physical/sizeAreaFloor",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Floor area size",
+            "fi-fi": "Pinta-ala/Kerrosala"
+        },
+        "rdfs:comment": {
+            "en-us": "Area of the space"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Space.jsonld
+++ b/v1/Vocabulary/Space.jsonld
@@ -63,22 +63,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "fi-fi": "Tilan kuvaus",
-            "en-us": "Space description"
+            "en-us": "Space description",
+            "fi-fi": "Tilan kuvaus"
         },
         "rdfs:comment": {
             "en-us": "Description of the space"
         },
         "domain": [
-            "pot:Device",
+            "pot:Space",
+            "pot:Storey",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
             "pot:Room",
+            "pot:Case",
             "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
         ],
         "range": [
             "xsd:string"
@@ -86,27 +86,48 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "height": {
+        "@id": "pot:physical/height",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the space"
+            "en-us": "Height of the space"
         },
         "domain": [
             "pot:Device",
             "pot:Building",
-            "pot:Story",
-            "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "usageMain": {
+        "@id": "pot:categorization/usageMain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "Käyttötarkoitus",
+            "en-us": "Main usage purpose"
+        },
+        "rdfs:comment": {
+            "en-us": "Main usage purpose"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:RealEstate",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -123,9 +144,80 @@
             "en-us": "Size of audited area suitable for, or used for, living"
         },
         "domain": [
-            "pot:Space",
+            "pot:Storey",
             "pot:Room",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "idOfficial": {
+        "@id": "pot:identifier/idOfficial",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Official Id",
+            "fi-fi": "Viranomaisen tunniste"
+        },
+        "rdfs:comment": {
+            "en-us": "Officially given identifier for the space in Finland"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:RealEstate",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Building",
+            "pot:RealEstate",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaLiving": {
+        "@id": "pot:physical/sizeAreaLiving",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Living area size",
+            "fi-fi": "Huoneistoala/Asuinpinta-ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Size of area suitable for, or used for, living"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Space",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -155,30 +247,30 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "sizeAreaLiving": {
-        "@id": "pot:physical/sizeAreaLiving",
+    "additionalInformation": {
+        "@id": "pot:description/additionalInformation",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "en-us": "Living area size",
-            "fi-fi": "Huoneistoala/Asuinpinta-ala"
+            "en-us": "Additional information",
+            "fi-fi": "Lisätiedot"
         },
         "rdfs:comment": {
-            "en-us": "Size of area suitable for, or used for, living"
+            "en-us": "Additional information"
         },
         "domain": [
-            "pot:Story",
-            "pot:Space",
-            "pot:Room"
+            "pot:Room",
+            "pot:Storey",
+            "pot:Space"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idlocal": {
-        "@id": "pot:identifier/idlocal",
+    "idLocal": {
+        "@id": "pot:identifier/idLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
@@ -189,10 +281,10 @@
             "en-us": "Locally given identifier for the space"
         },
         "domain": [
-            "pot:Story",
-            "pot:Space",
+            "pot:Case",
             "pot:Room",
-            "pot:Case"
+            "pot:Space",
+            "pot:Storey"
         ],
         "range": [
             "xsd:string"
@@ -212,111 +304,10 @@
             "en-us": "Space type name derived from local categorization naming"
         },
         "domain": [
-            "pot:Device",
             "pot:Room",
             "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "idOfficial": {
-        "@id": "pot:identifier/idOfficial",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "Viranomaisen tunniste",
-            "en-us": "Official Id"
-        },
-        "rdfs:comment": {
-            "en-us": "Officially given identifier for the space in Finland"
-        },
-        "domain": [
-            "pot:Room",
-            "pot:Space",
-            "pot:RealEstate"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
             "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
             "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
-        },
-        "rdfs:comment": {
-            "en-us": "Height of the space"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
         ],
         "range": [
             "xsd:string"
@@ -329,14 +320,39 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala/Kerrosala",
-            "en-us": "Floor area size"
+            "en-us": "Floor area size",
+            "fi-fi": "Pinta-ala/Kerrosala"
         },
         "rdfs:comment": {
             "en-us": "Area of the space"
         },
         "domain": [
+            "pot:Space",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the space"
+        },
+        "domain": [
             "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
             "pot:Space"
         ],
         "range": [
@@ -345,20 +361,26 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "additionalInformation": {
-        "@id": "pot:description/additionalInformation",
+    "status": {
+        "@id": "pot:lifeCycle/status",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Lisätiedot",
-            "en-us": "Additional information"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
-            "en-us": "Additional information"
+            "en-us": "Life cycle status"
         },
         "domain": [
+            "pot:Organization",
+            "pot:Storey",
             "pot:Space",
-            "pot:Story",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
             "pot:Room"
         ],
         "range": [
@@ -367,39 +389,17 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "usageMain": {
-        "@id": "pot:categorization/usageMain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Main usage purpose",
-            "fi-fi": "Käyttötarkoitus"
-        },
-        "rdfs:comment": {
-            "en-us": "Main usage purpose"
-        },
-        "domain": [
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "Apartment": {
-        "rdfs:subClassOf": {
-            "@id": "pot:Space"
-        }
-    },
     "RealEstate": {
         "rdfs:subClassOf": {
             "@id": "pot:Space"
         }
     },
     "Zone": {
+        "rdfs:subClassOf": {
+            "@id": "pot:Space"
+        }
+    },
+    "Apartment": {
         "rdfs:subClassOf": {
             "@id": "pot:Space"
         }

--- a/v1/Vocabulary/Space/Apartment.jsonld
+++ b/v1/Vocabulary/Space/Apartment.jsonld
@@ -61,48 +61,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "fi-fi": "Tilan kuvaus",
-            "en-us": "Space description"
+            "en-us": "Space description",
+            "fi-fi": "Tilan kuvaus"
         },
         "rdfs:comment": {
             "en-us": "Description of the space"
         },
         "domain": [
-            "pot:Device",
+            "pot:Space",
+            "pot:Storey",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
             "pot:Room",
+            "pot:Case",
             "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Apartment name",
-            "fi-fi": "Huoneistotunnus"
-        },
-        "rdfs:comment": {
-            "en-us": "Apartment name"
-        },
-        "domain": [
             "pot:Device",
             "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:BuildingElement"
+            "pot:Building"
         ],
         "range": [
             "xsd:string"
@@ -110,24 +84,23 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "height": {
+        "@id": "pot:physical/height",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the space"
+            "en-us": "Height of the space"
         },
         "domain": [
             "pot:Device",
             "pot:Building",
-            "pot:Story",
-            "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -135,19 +108,21 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionKitchen": {
-        "@id": "pot:description/descriptionKitchen",
+    "usageMain": {
+        "@id": "pot:categorization/usageMain",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Kitchen type",
-            "fi-fi": "Keittiölaji"
+            "fi-fi": "Käyttötarkoitus",
+            "en-us": "Main usage purpose"
         },
         "rdfs:comment": {
-            "en-us": "Type of kitchen in the apartment"
+            "en-us": "Main usage purpose"
         },
         "domain": [
-            "pot:Apartment"
+            "pot:Space",
+            "pot:RealEstate",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -167,12 +142,87 @@
             "en-us": "Size of audited area suitable for, or used for, living"
         },
         "domain": [
-            "pot:Space",
+            "pot:Storey",
             "pot:Room",
-            "pot:Story"
+            "pot:Space"
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "idOfficial": {
+        "@id": "pot:identifier/idOfficial",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Official Id",
+            "fi-fi": "Viranomaisen tunniste"
+        },
+        "rdfs:comment": {
+            "en-us": "Officially given identifier for the space in Finland"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:RealEstate",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Building",
+            "pot:RealEstate",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Apartment name",
+            "fi-fi": "Huoneistotunnus"
+        },
+        "rdfs:comment": {
+            "en-us": "Apartment name"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -199,6 +249,51 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
+    "additionalInformation": {
+        "@id": "pot:description/additionalInformation",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "en-us": "Additional information",
+            "fi-fi": "Lisätiedot"
+        },
+        "rdfs:comment": {
+            "en-us": "Additional information"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "idLocal": {
+        "@id": "pot:identifier/idLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen tunniste",
+            "en-us": "Local Id"
+        },
+        "rdfs:comment": {
+            "en-us": "Locally given identifier for the space"
+        },
+        "domain": [
+            "pot:Case",
+            "pot:Room",
+            "pot:Space",
+            "pot:Storey"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
     "sizeAreaLiving": {
         "@id": "pot:physical/sizeAreaLiving",
         "@type": "rdf:Property",
@@ -211,35 +306,12 @@
             "en-us": "Size of area suitable for, or used for, living"
         },
         "domain": [
-            "pot:Story",
+            "pot:Storey",
             "pot:Space",
             "pot:Room"
         ],
         "range": [
             "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "idlocal": {
-        "@id": "pot:identifier/idlocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "Paikallinen tunniste",
-            "en-us": "Local Id"
-        },
-        "rdfs:comment": {
-            "en-us": "Locally given identifier for the space"
-        },
-        "domain": [
-            "pot:Story",
-            "pot:Space",
-            "pot:Room",
-            "pot:Case"
-        ],
-        "range": [
-            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -256,10 +328,10 @@
             "en-us": "Space type name derived from local categorization naming"
         },
         "domain": [
-            "pot:Device",
             "pot:Room",
             "pot:Space",
-            "pot:BuildingElement"
+            "pot:BuildingElement",
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -267,24 +339,68 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idOfficial": {
-        "@id": "pot:identifier/idOfficial",
+    "descriptionKitchen": {
+        "@id": "pot:description/descriptionKitchen",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
+        "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "fi-fi": "Viranomaisen tunniste",
-            "en-us": "Official Id"
+            "fi-fi": "Keittiölaji",
+            "en-us": "Kitchen type"
         },
         "rdfs:comment": {
-            "en-us": "Officially given identifier for the space in Finland"
+            "en-us": "Type of kitchen in the apartment"
         },
         "domain": [
-            "pot:Room",
-            "pot:Space",
-            "pot:RealEstate"
+            "pot:Apartment"
         ],
         "range": [
             "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaFloor": {
+        "@id": "pot:physical/sizeAreaFloor",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Floor area size",
+            "fi-fi": "Pinta-ala/Kerrosala"
+        },
+        "rdfs:comment": {
+            "en-us": "Area of the space"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the space"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -294,73 +410,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
             "en-us": "Life cycle status"
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
+            "pot:Storey",
+            "pot:Space",
             "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
             "pot:Case",
-            "pot:Space",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
-        },
-        "rdfs:comment": {
-            "en-us": "Height of the space"
-        },
-        "domain": [
-            "pot:Device",
             "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Room"
         ],
         "range": [
             "xsd:string"
@@ -384,71 +449,6 @@
         ],
         "range": [
             "xsd:int"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "sizeAreaFloor": {
-        "@id": "pot:physical/sizeAreaFloor",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pinta-ala/Kerrosala",
-            "en-us": "Floor area size"
-        },
-        "rdfs:comment": {
-            "en-us": "Area of the space"
-        },
-        "domain": [
-            "pot:Room",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "additionalInformation": {
-        "@id": "pot:description/additionalInformation",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "fi-fi": "Lisätiedot",
-            "en-us": "Additional information"
-        },
-        "rdfs:comment": {
-            "en-us": "Additional information"
-        },
-        "domain": [
-            "pot:Space",
-            "pot:Story",
-            "pot:Room"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "usageMain": {
-        "@id": "pot:categorization/usageMain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Main usage purpose",
-            "fi-fi": "Käyttötarkoitus"
-        },
-        "rdfs:comment": {
-            "en-us": "Main usage purpose"
-        },
-        "domain": [
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Space/RealEstate.jsonld
+++ b/v1/Vocabulary/Space/RealEstate.jsonld
@@ -56,6 +56,33 @@
             "en-us": "Real estate is property consisting of land and the buildings on it, along with its natural resources such as crops, minerals or water; immovable property of this nature; an interest vested in this (also) an item of real property, (more generally) buildings or housing in general."
         }
     },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Building",
+            "pot:RealEstate",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
     "categorizationOfficial": {
         "@id": "pot:categorization/categorizationOfficial",
         "@type": "rdf:Property",
@@ -78,167 +105,8 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "areaTypeRegistration": {
-        "@id": "pot:categorization/areaTypeRegistration",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Registration type",
-            "fi-fi": "Rekisteriyksikkölaji"
-        },
-        "rdfs:comment": {
-            "en-us": "Land registration type"
-        },
-        "domain": [
-            "pot:RealEstate"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "categorizationLocal": {
-        "@id": "pot:categorization/categorizationLocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Tilatyyppi - paikallinen",
-            "en-us": "Space type - local"
-        },
-        "rdfs:comment": {
-            "en-us": "Space type name derived from local categorization naming"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Room",
-            "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
-        },
-        "rdfs:comment": {
-            "en-us": "Height of the space"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "sizeAreaFloor": {
-        "@id": "pot:physical/sizeAreaFloor",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Pinta-ala/Kerrosala",
-            "en-us": "Floor area size"
-        },
-        "rdfs:comment": {
-            "en-us": "Area of the space"
-        },
-        "domain": [
-            "pot:Room",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "IFC GUID",
-            "fi-fi": "IFC GUID"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "usageMain": {
-        "@id": "pot:categorization/usageMain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Käyttötarkoitus",
-            "en-us": "Main usage purpose"
-        },
-        "rdfs:comment": {
-            "en-us": "Main usage purpose"
-        },
-        "domain": [
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "sizeAreaLiving": {
-        "@id": "pot:physical/sizeAreaLiving",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Living area size",
-            "fi-fi": "Huoneistoala/Asuinpinta-ala"
-        },
-        "rdfs:comment": {
-            "en-us": "Size of area suitable for, or used for, living"
-        },
-        "domain": [
-            "pot:Story",
-            "pot:Space",
-            "pot:Room"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "idlocal": {
-        "@id": "pot:identifier/idlocal",
+    "idLocal": {
+        "@id": "pot:identifier/idLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
@@ -249,10 +117,10 @@
             "en-us": "Locally given identifier for the space"
         },
         "domain": [
-            "pot:Story",
-            "pot:Space",
+            "pot:Case",
             "pot:Room",
-            "pot:Case"
+            "pot:Space",
+            "pot:Storey"
         ],
         "range": [
             "xsd:string"
@@ -276,6 +144,68 @@
         ],
         "range": [
             "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "areaTypeRegistration": {
+        "@id": "pot:categorization/areaTypeRegistration",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "Rekisteriyksikkölaji",
+            "en-us": "Registration type"
+        },
+        "rdfs:comment": {
+            "en-us": "Land registration type"
+        },
+        "domain": [
+            "pot:RealEstate"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "locationUnseparatedLand": {
+        "@id": "pot:categorization/locationUnseparatedLand",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "Sijaitsee määräalalla",
+            "en-us": "Location on unseparated piece of land"
+        },
+        "rdfs:comment": {
+            "en-us": "Real estate is located on an unseparated piece of land"
+        },
+        "domain": [
+            "pot:RealEstate"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaLivingAudited": {
+        "@id": "pot:physical/sizeAreaLivingAudited",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Asuinpinta-ala - tarkistusmitattu",
+            "en-us": "Audited living area size"
+        },
+        "rdfs:comment": {
+            "en-us": "Size of audited area suitable for, or used for, living"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Room",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -305,8 +235,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "en-us": "Area in square meters",
-            "fi-fi": "Pinta-ala"
+            "fi-fi": "Pinta-ala",
+            "en-us": "Area in square meters"
         },
         "rdfs:comment": {
             "en-us": "Area measured in square meters"
@@ -320,53 +250,22 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "descriptionGeneral": {
-        "@id": "pot:description/descriptionGeneral",
+    "categorizationLocal": {
+        "@id": "pot:categorization/categorizationLocal",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "en-us": "Space description",
-            "fi-fi": "Kiinteistön kuvaus"
+            "fi-fi": "Tilatyyppi - paikallinen",
+            "en-us": "Space type - local"
         },
         "rdfs:comment": {
-            "en-us": "Description of the space"
+            "en-us": "Space type name derived from local categorization naming"
         },
         "domain": [
-            "pot:Device",
+            "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "name": {
-        "@id": "pot:identifier/name",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "Name",
-            "fi-fi": "Kiinteistön nimi"
-        },
-        "rdfs:comment": {
-            "en-us": "Name of the real estate"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Organization",
-            "pot:Building",
-            "pot:Apartment",
-            "pot:Room",
-            "pot:RealEstate",
-            "pot:BuildingElement"
+            "pot:Device"
         ],
         "range": [
             "xsd:string"
@@ -386,107 +285,15 @@
             "en-us": "Volume of the space"
         },
         "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Story",
             "pot:Room",
+            "pot:Storey",
             "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
             "pot:Space"
         ],
         "range": [
             "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "sizeAreaLivingAudited": {
-        "@id": "pot:physical/sizeAreaLivingAudited",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Asuinpinta-ala - tarkistusmitattu",
-            "en-us": "Audited living area size"
-        },
-        "rdfs:comment": {
-            "en-us": "Size of audited area suitable for, or used for, living"
-        },
-        "domain": [
-            "pot:Space",
-            "pot:Room",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "idOfficial": {
-        "@id": "pot:identifier/idOfficial",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "Viranomaisen tunniste",
-            "en-us": "Real estate Id"
-        },
-        "rdfs:comment": {
-            "en-us": "Officially given identifier for the space in Finland"
-        },
-        "domain": [
-            "pot:Room",
-            "pot:Space",
-            "pot:RealEstate"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "locationUnseparatedLand": {
-        "@id": "pot:categorization/locationUnseparatedLand",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "fi-fi": "Sijaitsee määräalalla",
-            "en-us": "Location on unseparated piece of land"
-        },
-        "rdfs:comment": {
-            "en-us": "Real estate is located on an unseparated piece of land"
-        },
-        "domain": [
-            "pot:RealEstate"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -496,8 +303,8 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:categorization",
         "rdfs:label": {
-            "fi-fi": "Kiinteistölaji",
-            "en-us": "Real estate type"
+            "en-us": "Real estate type",
+            "fi-fi": "Kiinteistölaji"
         },
         "rdfs:comment": {
             "en-us": "Type of land defined officially"
@@ -511,24 +318,217 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
+    "descriptionGeneral": {
+        "@id": "pot:description/descriptionGeneral",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "en-us": "Space description",
+            "fi-fi": "Tilan kuvaus"
+        },
+        "rdfs:comment": {
+            "en-us": "Description of the space"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Case",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "height": {
+        "@id": "pot:physical/height",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
+        },
+        "rdfs:comment": {
+            "en-us": "Height of the space"
+        },
+        "domain": [
+            "pot:Device",
+            "pot:Building",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaLiving": {
+        "@id": "pot:physical/sizeAreaLiving",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Living area size",
+            "fi-fi": "Huoneistoala/Asuinpinta-ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Size of area suitable for, or used for, living"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Space",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "status": {
+        "@id": "pot:lifeCycle/status",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:lifeCycle",
+        "rdfs:label": {
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
+        },
+        "rdfs:comment": {
+            "en-us": "Life cycle status"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:Storey",
+            "pot:Space",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "usageMain": {
+        "@id": "pot:categorization/usageMain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "Käyttötarkoitus",
+            "en-us": "Main usage purpose"
+        },
+        "rdfs:comment": {
+            "en-us": "Main usage purpose"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:RealEstate",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "idOfficial": {
+        "@id": "pot:identifier/idOfficial",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Kiinteistötunnus",
+            "en-us": "Real estate Id"
+        },
+        "rdfs:comment": {
+            "en-us": "Real estate identifier for the land in Finland"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:RealEstate",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "name": {
+        "@id": "pot:identifier/name",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Kiinteistön nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the real estate"
+        },
+        "domain": [
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:RealEstate",
+            "pot:Room",
+            "pot:Building",
+            "pot:Device",
+            "pot:Apartment"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
     "additionalInformation": {
         "@id": "pot:description/additionalInformation",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "fi-fi": "Lisätiedot",
-            "en-us": "Additional information"
+            "en-us": "Additional information",
+            "fi-fi": "Lisätiedot"
         },
         "rdfs:comment": {
             "en-us": "Additional information"
         },
         "domain": [
-            "pot:Space",
-            "pot:Story",
-            "pot:Room"
+            "pot:Room",
+            "pot:Storey",
+            "pot:Space"
         ],
         "range": [
             "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaFloor": {
+        "@id": "pot:physical/sizeAreaFloor",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Floor area size",
+            "fi-fi": "Pinta-ala/Kerrosala"
+        },
+        "rdfs:comment": {
+            "en-us": "Area of the space"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"

--- a/v1/Vocabulary/Space/Zone.jsonld
+++ b/v1/Vocabulary/Space/Zone.jsonld
@@ -61,22 +61,22 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "fi-fi": "Tilan kuvaus",
-            "en-us": "Space description"
+            "en-us": "Space description",
+            "fi-fi": "Tilan kuvaus"
         },
         "rdfs:comment": {
             "en-us": "Description of the space"
         },
         "domain": [
-            "pot:Device",
+            "pot:Space",
+            "pot:Storey",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
             "pot:Room",
+            "pot:Case",
             "pot:RealEstate",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
         ],
         "range": [
             "xsd:string"
@@ -84,27 +84,48 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "volume": {
-        "@id": "pot:physical/volume",
+    "height": {
+        "@id": "pot:physical/height",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Tilavuus",
-            "en-us": "Volume"
+            "en-us": "Height",
+            "fi-fi": "Korkeus"
         },
         "rdfs:comment": {
-            "en-us": "Volume of the space"
+            "en-us": "Height of the space"
         },
         "domain": [
             "pot:Device",
             "pot:Building",
-            "pot:Story",
-            "pot:Room",
+            "pot:Space",
             "pot:BuildingElement",
-            "pot:Space"
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "usageMain": {
+        "@id": "pot:categorization/usageMain",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:categorization",
+        "rdfs:label": {
+            "fi-fi": "Käyttötarkoitus",
+            "en-us": "Main usage purpose"
+        },
+        "rdfs:comment": {
+            "en-us": "Main usage purpose"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:RealEstate",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -121,9 +142,80 @@
             "en-us": "Size of audited area suitable for, or used for, living"
         },
         "domain": [
-            "pot:Space",
+            "pot:Storey",
             "pot:Room",
-            "pot:Story"
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "idOfficial": {
+        "@id": "pot:identifier/idOfficial",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "Official Id",
+            "fi-fi": "Viranomaisen tunniste"
+        },
+        "rdfs:comment": {
+            "en-us": "Officially given identifier for the space in Finland"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:RealEstate",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
+            "pot:Building",
+            "pot:RealEstate",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaLiving": {
+        "@id": "pot:physical/sizeAreaLiving",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Living area size",
+            "fi-fi": "Huoneistoala/Asuinpinta-ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Size of area suitable for, or used for, living"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Space",
+            "pot:Room"
         ],
         "range": [
             "xsd:decimal"
@@ -153,30 +245,30 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "sizeAreaLiving": {
-        "@id": "pot:physical/sizeAreaLiving",
+    "additionalInformation": {
+        "@id": "pot:description/additionalInformation",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
+        "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "en-us": "Living area size",
-            "fi-fi": "Huoneistoala/Asuinpinta-ala"
+            "en-us": "Additional information",
+            "fi-fi": "Lisätiedot"
         },
         "rdfs:comment": {
-            "en-us": "Size of area suitable for, or used for, living"
+            "en-us": "Additional information"
         },
         "domain": [
-            "pot:Story",
-            "pot:Space",
-            "pot:Room"
+            "pot:Room",
+            "pot:Storey",
+            "pot:Space"
         ],
         "range": [
-            "xsd:decimal"
+            "xsd:string"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "idlocal": {
-        "@id": "pot:identifier/idlocal",
+    "idLocal": {
+        "@id": "pot:identifier/idLocal",
         "@type": "rdf:Property",
         "subPropertyOf": "pot:identifier",
         "rdfs:label": {
@@ -187,10 +279,10 @@
             "en-us": "Locally given identifier for the space"
         },
         "domain": [
-            "pot:Story",
-            "pot:Space",
+            "pot:Case",
             "pot:Room",
-            "pot:Case"
+            "pot:Space",
+            "pot:Storey"
         ],
         "range": [
             "xsd:string"
@@ -210,111 +302,10 @@
             "en-us": "Space type name derived from local categorization naming"
         },
         "domain": [
-            "pot:Device",
             "pot:Room",
             "pot:Space",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "idOfficial": {
-        "@id": "pot:identifier/idOfficial",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "Viranomaisen tunniste",
-            "en-us": "Official Id"
-        },
-        "rdfs:comment": {
-            "en-us": "Officially given identifier for the space in Finland"
-        },
-        "domain": [
-            "pot:Room",
-            "pot:Space",
-            "pot:RealEstate"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "status": {
-        "@id": "pot:lifeCycle/status",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:lifeCycle",
-        "rdfs:label": {
-            "fi-fi": "Elinkaari - Status",
-            "en-us": "Life cycle status"
-        },
-        "rdfs:comment": {
-            "en-us": "Life cycle status"
-        },
-        "domain": [
-            "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
             "pot:BuildingElement",
-            "pot:Case",
-            "pot:Space",
             "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "height": {
-        "@id": "pot:physical/height",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Korkeus",
-            "en-us": "Height"
-        },
-        "rdfs:comment": {
-            "en-us": "Height of the space"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:Building",
-            "pot:Space",
-            "pot:Room",
-            "pot:BuildingElement"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "IFC GUID",
-            "en-us": "IFC GUID"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
-        },
-        "domain": [
-            "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
-            "pot:Building",
-            "pot:Space"
         ],
         "range": [
             "xsd:string"
@@ -327,14 +318,39 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:physical",
         "rdfs:label": {
-            "fi-fi": "Pinta-ala/Kerrosala",
-            "en-us": "Floor area size"
+            "en-us": "Floor area size",
+            "fi-fi": "Pinta-ala/Kerrosala"
         },
         "rdfs:comment": {
             "en-us": "Area of the space"
         },
         "domain": [
+            "pot:Space",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "volume": {
+        "@id": "pot:physical/volume",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Tilavuus",
+            "en-us": "Volume"
+        },
+        "rdfs:comment": {
+            "en-us": "Volume of the space"
+        },
+        "domain": [
             "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
+            "pot:Building",
+            "pot:Device",
             "pot:Space"
         ],
         "range": [
@@ -343,43 +359,27 @@
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
     },
-    "additionalInformation": {
-        "@id": "pot:description/additionalInformation",
+    "status": {
+        "@id": "pot:lifeCycle/status",
         "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
+        "subPropertyOf": "pot:lifeCycle",
         "rdfs:label": {
-            "fi-fi": "Lisätiedot",
-            "en-us": "Additional information"
+            "en-us": "Life cycle status",
+            "fi-fi": "Elinkaari - Status"
         },
         "rdfs:comment": {
-            "en-us": "Additional information"
+            "en-us": "Life cycle status"
         },
         "domain": [
+            "pot:Organization",
+            "pot:Storey",
             "pot:Space",
-            "pot:Story",
-            "pot:Room"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "usageMain": {
-        "@id": "pot:categorization/usageMain",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:categorization",
-        "rdfs:label": {
-            "en-us": "Main usage purpose",
-            "fi-fi": "Käyttötarkoitus"
-        },
-        "rdfs:comment": {
-            "en-us": "Main usage purpose"
-        },
-        "domain": [
+            "pot:BuildingElement",
             "pot:RealEstate",
-            "pot:Room",
-            "pot:Space"
+            "pot:Device",
+            "pot:Case",
+            "pot:Building",
+            "pot:Room"
         ],
         "range": [
             "xsd:string"

--- a/v1/Vocabulary/Storey.jsonld
+++ b/v1/Vocabulary/Storey.jsonld
@@ -43,17 +43,17 @@
             ]
         }
     },
-    "Story": {
-        "@id": "pot:Story",
+    "Storey": {
+        "@id": "pot:Storey",
         "@type": "pot:Class",
         "subClassOf": "dli:BuiltEnvironment",
         "vs:term_status": "unstable",
         "owl:versionInfo": "DRAFT",
         "rdfs:label": {
-            "en-us": "Story"
+            "en-us": "Storey"
         },
         "rdfs:comment": {
-            "en-us": "A Story is the bottom surface of a room or vehicle (also called floor)"
+            "en-us": "A Storey is the bottom surface of a room or vehicle (also called floor)"
         }
     },
     "descriptionGeneral": {
@@ -61,25 +61,183 @@
         "@type": "rdf:Property",
         "subPropertyOf": "pot:description",
         "rdfs:label": {
-            "en-us": "Story description",
-            "fi-fi": "Kerroksen kuvaus"
+            "fi-fi": "Kerroksen kuvaus",
+            "en-us": "Storey description"
         },
         "rdfs:comment": {
-            "en-us": "Description of the story"
+            "en-us": "Description of the storey"
         },
         "domain": [
-            "pot:Device",
+            "pot:Space",
+            "pot:Storey",
             "pot:BuildingElement",
-            "pot:Organization",
-            "pot:Case",
             "pot:Room",
+            "pot:Case",
             "pot:RealEstate",
-            "pot:Story",
+            "pot:Device",
+            "pot:Organization",
+            "pot:Building"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaLivingAudited": {
+        "@id": "pot:physical/sizeAreaLivingAudited",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Asuinpinta-ala - tarkistusmitattu",
+            "en-us": "Audited living area size"
+        },
+        "rdfs:comment": {
+            "en-us": "Size of audited area suitable for, or used for, living"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Room",
+            "pot:Space"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "ifcGuid": {
+        "@id": "pot:identifier/ifcGuid",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "en-us": "IFC GUID",
+            "fi-fi": "IFC GUID"
+        },
+        "rdfs:comment": {
+            "en-us": "IFC standard based Globally Unique Identifier"
+        },
+        "domain": [
+            "pot:Space",
+            "pot:Storey",
+            "pot:Organization",
+            "pot:BuildingElement",
+            "pot:Room",
             "pot:Building",
+            "pot:RealEstate",
+            "pot:Device"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeAreaLiving": {
+        "@id": "pot:physical/sizeAreaLiving",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Living area size",
+            "fi-fi": "Huoneistoala/Asuinpinta-ala"
+        },
+        "rdfs:comment": {
+            "en-us": "Size of area suitable for, or used for, living"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Space",
+            "pot:Room"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "additionalInformation": {
+        "@id": "pot:description/additionalInformation",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:description",
+        "rdfs:label": {
+            "en-us": "Additional information",
+            "fi-fi": "Lisätiedot"
+        },
+        "rdfs:comment": {
+            "en-us": "Additional information"
+        },
+        "domain": [
+            "pot:Room",
+            "pot:Storey",
             "pot:Space"
         ],
         "range": [
             "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "thickness": {
+        "@id": "pot:physical/thickness",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "fi-fi": "Paksuus",
+            "en-us": "Thickness"
+        },
+        "rdfs:comment": {
+            "en-us": "Thickness of the object"
+        },
+        "domain": [
+            "pot:Storey",
+            "pot:Device",
+            "pot:BuildingElement"
+        ],
+        "range": [
+            "xsd:decimal"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "idLocal": {
+        "@id": "pot:identifier/idLocal",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:identifier",
+        "rdfs:label": {
+            "fi-fi": "Paikallinen tunniste",
+            "en-us": "Local Id"
+        },
+        "rdfs:comment": {
+            "en-us": "Locally given identifier for the storey"
+        },
+        "domain": [
+            "pot:Case",
+            "pot:Room",
+            "pot:Space",
+            "pot:Storey"
+        ],
+        "range": [
+            "xsd:string"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "sizeArea": {
+        "@id": "pot:physical/sizeArea",
+        "@type": "rdf:Property",
+        "subPropertyOf": "pot:physical",
+        "rdfs:label": {
+            "en-us": "Storey area size",
+            "fi-fi": "Pinta-ala/Kerrosala"
+        },
+        "rdfs:comment": {
+            "en-us": "Area of the storey"
+        },
+        "domain": [
+            "pot:Storey"
+        ],
+        "range": [
+            "xsd:decimal"
         ],
         "owl:versionInfo": "DRAFT",
         "vs:term_status": "unstable"
@@ -96,121 +254,12 @@
             "en-us": "Volume of the object"
         },
         "domain": [
-            "pot:Device",
+            "pot:Room",
+            "pot:Storey",
+            "pot:BuildingElement",
             "pot:Building",
-            "pot:Story",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "sizeAreaLivingAudited": {
-        "@id": "pot:physical/sizeAreaLivingAudited",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Audited living area size",
-            "fi-fi": "Asuinpinta-ala - tarkistusmitattu"
-        },
-        "rdfs:comment": {
-            "en-us": "Size of audited area suitable for, or used for, living"
-        },
-        "domain": [
-            "pot:Space",
-            "pot:Room",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "sizeAreaLiving": {
-        "@id": "pot:physical/sizeAreaLiving",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "fi-fi": "Huoneistoala/Asuinpinta-ala",
-            "en-us": "Living area size"
-        },
-        "rdfs:comment": {
-            "en-us": "Size of area suitable for, or used for, living"
-        },
-        "domain": [
-            "pot:Story",
-            "pot:Space",
-            "pot:Room"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "thickness": {
-        "@id": "pot:physical/thickness",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Thickness",
-            "fi-fi": "Paksuus"
-        },
-        "rdfs:comment": {
-            "en-us": "Thickness of the object"
-        },
-        "domain": [
-            "pot:BuildingElement",
             "pot:Device",
-            "pot:Story"
-        ],
-        "range": [
-            "xsd:decimal"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "idlocal": {
-        "@id": "pot:identifier/idlocal",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "fi-fi": "Paikallinen tunniste",
-            "en-us": "Local Id"
-        },
-        "rdfs:comment": {
-            "en-us": "Locally given identifier for the story"
-        },
-        "domain": [
-            "pot:Story",
-            "pot:Space",
-            "pot:Room",
-            "pot:Case"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "sizeArea": {
-        "@id": "pot:physical/sizeArea",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:physical",
-        "rdfs:label": {
-            "en-us": "Story area size",
-            "fi-fi": "Pinta-ala/Kerrosala"
-        },
-        "rdfs:comment": {
-            "en-us": "Area of the story"
-        },
-        "domain": [
-            "pot:Story"
+            "pot:Space"
         ],
         "range": [
             "xsd:decimal"
@@ -231,62 +280,13 @@
         },
         "domain": [
             "pot:Organization",
-            "pot:Building",
-            "pot:Story",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:BuildingElement",
-            "pot:Case",
+            "pot:Storey",
             "pot:Space",
-            "pot:Device"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "ifcGuid": {
-        "@id": "pot:identifier/ifcGuid",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:identifier",
-        "rdfs:label": {
-            "en-us": "IFC GUID",
-            "fi-fi": "IFC GUID"
-        },
-        "rdfs:comment": {
-            "en-us": "IFC standard based Globally Unique Identifier"
-        },
-        "domain": [
+            "pot:BuildingElement",
+            "pot:RealEstate",
             "pot:Device",
-            "pot:BuildingElement",
-            "pot:Organization",
-            "pot:RealEstate",
-            "pot:Room",
-            "pot:Story",
+            "pot:Case",
             "pot:Building",
-            "pot:Space"
-        ],
-        "range": [
-            "xsd:string"
-        ],
-        "owl:versionInfo": "DRAFT",
-        "vs:term_status": "unstable"
-    },
-    "additionalInformation": {
-        "@id": "pot:description/additionalInformation",
-        "@type": "rdf:Property",
-        "subPropertyOf": "pot:description",
-        "rdfs:label": {
-            "fi-fi": "Lisätiedot",
-            "en-us": "Additional information"
-        },
-        "rdfs:comment": {
-            "en-us": "Additional information"
-        },
-        "domain": [
-            "pot:Space",
-            "pot:Story",
             "pot:Room"
         ],
         "range": [

--- a/v1/Vocabulary/SupportedAttribute.jsonld
+++ b/v1/Vocabulary/SupportedAttribute.jsonld
@@ -54,5 +54,68 @@
         "rdfs:comment": {
             "en-us": "Attribuutti jonka tiedetään kuuluvan identiteettiin"
         }
+    },
+    "lifeCycle": {
+        "@id": "pot:lifeCycle",
+        "@type": "rdf:Property",
+        "domain": [
+            "dli:SupportedAttribute"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "physical": {
+        "@id": "pot:physical",
+        "@type": "rdf:Property",
+        "domain": [
+            "dli:SupportedAttribute"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "identifier": {
+        "@id": "pot:identifier",
+        "@type": "rdf:Property",
+        "domain": [
+            "dli:SupportedAttribute"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "administration": {
+        "@id": "pot:administration",
+        "@type": "rdf:Property",
+        "domain": [
+            "dli:SupportedAttribute"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "categorization": {
+        "@id": "pot:categorization",
+        "@type": "rdf:Property",
+        "domain": [
+            "dli:SupportedAttribute"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "description": {
+        "@id": "pot:description",
+        "@type": "rdf:Property",
+        "domain": [
+            "dli:SupportedAttribute"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
+    },
+    "time": {
+        "@id": "pot:time",
+        "@type": "rdf:Property",
+        "domain": [
+            "dli:SupportedAttribute"
+        ],
+        "owl:versionInfo": "DRAFT",
+        "vs:term_status": "unstable"
     }
 }


### PR DESCRIPTION
Unfortunately due to serialization used, files are not generated in consistent way (order of properties can change), that's why a lot of diff garbage generated. 
I'll try to fix it in next version to make review possible.

Release scope:
- Create `/` -> `/v1/` redirect
- Fix context redirects when trailing slash is used ex. https://standards.oftrust.net/v1/Context/Identity/Building/. It started failing after rearranging folders `Identity` and `Link`
- Solve problem when there is a need to add property from parent ontology to class in child ontology. Messed inheritance (duplicated properties in several parent classes) ex. https://standards.oftrust.net/v1/class-housingcooperative.html
- Some tehcnical properties appear in documentation, ex. `dli:supportedAttribute` for `pot:Room`  https://standards.oftrust.net/v1/class-room.html
- Sometimes labels get duplicated even if they are same for properties. Ex. https://standards.oftrust.net/v1/prop-additionalinformation.html. There will be some cases still left after update, but there is no possibility to fix in current viewer version.
- Add classes pot:QrCode and pot:HumiditySensor
- Rename `Story` -> `Storey`